### PR TITLE
chore: remove API key assertion within examples

### DIFF
--- a/javascript/playwright/test/heroku.e2e.js
+++ b/javascript/playwright/test/heroku.e2e.js
@@ -8,10 +8,6 @@ require('dotenv').config({
 
 const { AXE_SERVER_URL, AXE_WATCHER_API_KEY } = process.env
 
-if (!AXE_WATCHER_API_KEY) {
-  throw new Error('AXE_WATCHER_API_KEY is not defined')
-}
-
 describe('My Login Application', () => {
   let page
   let browser

--- a/javascript/puppeteer/test/heroku.e2e.js
+++ b/javascript/puppeteer/test/heroku.e2e.js
@@ -9,10 +9,6 @@ const { puppeteerConfig, PuppeteerController } = require('@axe-core/watcher')
 
 const { AXE_SERVER_URL, AXE_WATCHER_API_KEY } = process.env
 
-if (!AXE_WATCHER_API_KEY) {
-  throw new Error('AXE_WATCHER_API_KEY is not defined')
-}
-
 describe('My Login Application', () => {
   let browser
   let page

--- a/javascript/wdio-config/test/wdio.conf.ts
+++ b/javascript/wdio-config/test/wdio.conf.ts
@@ -8,10 +8,6 @@ require('dotenv').config({
 
 const { AXE_SERVER_URL, AXE_WATCHER_API_KEY } = process.env
 
-if (!AXE_WATCHER_API_KEY) {
-  throw new Error('AXE_WATCHER_API_KEY is not defined')
-}
-
 const AXE_WATCHER_SESSION_ID = v4()
 
 const orgConfig: Options.Testrunner = {

--- a/javascript/wdio/test/heroku.e2e.js
+++ b/javascript/wdio/test/heroku.e2e.js
@@ -9,10 +9,6 @@ const { wdioConfig, WdioController } = require('@axe-core/watcher')
 
 const { AXE_SERVER_URL, AXE_WATCHER_API_KEY } = process.env
 
-if (!AXE_WATCHER_API_KEY) {
-  throw new Error('AXE_WATCHER_API_KEY is not defined')
-}
-
 describe('My Login Application', () => {
   let browser
   let controller

--- a/javascript/webdriver/test/heroku.e2e.js
+++ b/javascript/webdriver/test/heroku.e2e.js
@@ -8,10 +8,6 @@ require('dotenv').config({
 
 const { AXE_SERVER_URL, AXE_WATCHER_API_KEY } = process.env
 
-if (!AXE_WATCHER_API_KEY) {
-  throw new Error('AXE_WATCHER_API_KEY is not defined')
-}
-
 describe('My Login Application', () => {
   let driver
   let controller


### PR DESCRIPTION
Cleaning up the examples. 

We shouldn't need this assertion anymore, we consume the same `.env` from the root as per the docs.

https://github.com/dequelabs/axe-watcher-example/blob/main/README.md#configure-environment-variables