### PR TITLE
ci: Automatically update `@axe-core/watcher`

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -32,7 +32,7 @@ jobs:
           commit-message: 'chore: Update @axe-core/watcher'
           branch: auto-update-postgres-types
           base: develop
-          title: 'chore(server): Update Postgres types'
+          title: 'chore: Update @axe-core/watcher'
           body: |
             This patch updates version of [`@axe-core/watcher`](https://npmjs.org/@axe-core/watcher) to the latest `@next` version.
 


### PR DESCRIPTION
This patch adds a GitHub action for automatically updating `@axe-core/watcher` every night.