### PR TITLE
fix: avoid timeouts on mocha tests

### DIFF
--- a/playwright/basic/package.json
+++ b/playwright/basic/package.json
@@ -2,7 +2,7 @@
   "name": "basic",
   "private": true,
   "scripts": {
-    "test": "mocha"
+    "test": "mocha --timeout 10000"
   },
   "devDependencies": {
     "@axe-core/watcher": "^1.0.0-next.9c954530",

--- a/playwright/typescript-manual-mode/package.json
+++ b/playwright/typescript-manual-mode/package.json
@@ -2,7 +2,7 @@
   "name": "typescript-manual-mode",
   "private": true,
   "scripts": {
-    "test": "mocha --require ts-node/register --timeout 4000 test/*.test.ts"
+    "test": "mocha --require ts-node/register --timeout 10000 test/*.test.ts"
   },
   "devDependencies": {
     "@axe-core/watcher": "^1.0.0-next.9c954530",

--- a/wdio/basic/package.json
+++ b/wdio/basic/package.json
@@ -2,7 +2,7 @@
   "name": "basic",
   "private": true,
   "scripts": {
-    "test": "mocha --timeout 4000 --exit"
+    "test": "mocha --timeout 10000 --exit"
   },
   "devDependencies": {
     "@axe-core/watcher": "^1.0.0-next.9c954530",

--- a/wdio/typescript-manual-mode/package.json
+++ b/wdio/typescript-manual-mode/package.json
@@ -2,7 +2,7 @@
   "name": "typescript-manual-mode",
   "private": true,
   "scripts": {
-    "test": "mocha --require ts-node/register --timeout 4000 test/*.test.ts"
+    "test": "mocha --require ts-node/register --timeout 10000 test/*.test.ts"
   },
   "devDependencies": {
     "@axe-core/watcher": "^1.0.0-next.9c954530",

--- a/webdriverjs/basic/package.json
+++ b/webdriverjs/basic/package.json
@@ -2,7 +2,7 @@
   "name": "basic",
   "private": true,
   "scripts": {
-    "test": "mocha --timeout 4000"
+    "test": "mocha --timeout 10000"
   },
   "devDependencies": {
     "@axe-core/watcher": "^1.0.0-next.9c954530",

--- a/webdriverjs/typescript-manual-mode/package.json
+++ b/webdriverjs/typescript-manual-mode/package.json
@@ -2,7 +2,7 @@
   "name": "typescript-manual-mode",
   "private": true,
   "scripts": {
-    "test": "mocha --timeout 4000 --require ts-node/register test/*.test.ts"
+    "test": "mocha --timeout 10000 --require ts-node/register test/*.test.ts"
   },
   "devDependencies": {
     "@axe-core/watcher": "^1.0.0-next.9c954530",


### PR DESCRIPTION
Set timeout consistently across all mocha examples to 10000 (the highest previous setting)