### PR TITLE
feat: add Playwright automatic and manual-mode example

### DIFF
--- a/playwright/basic/package.json
+++ b/playwright/basic/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "basic",
+  "private": true,
+  "scripts": {
+    "test": "mocha --timeout 5000 'tests/login.js'"
+  },
+  "devDependencies": {
+    "@axe-core/watcher": "^1.8.2-next.41231a52",
+    "chai": "^4.3.7",
+    "mocha": "^10.2.0",
+    "playwright": "^1.33.0"
+  }
+}

--- a/playwright/basic/tests/login.js
+++ b/playwright/basic/tests/login.js
@@ -7,10 +7,7 @@ const {
 } = require('@axe-core/watcher')
 
 /* Get your configuration from environment variables. */
-const {
-  API_KEY = '900e0d86-b10a-445c-85a2-c8459178874c',
-  SERVER_URL = 'http://localhost:3000'
-} = process.env
+const { API_KEY, SERVER_URL } = process.env
 
 describe('My Login Application', () => {
   let browserContext

--- a/playwright/basic/tests/login.js
+++ b/playwright/basic/tests/login.js
@@ -1,0 +1,63 @@
+const { assert } = require('chai')
+const playwright = require('playwright')
+const {
+  wrapPlaywright,
+  PlaywrightController,
+  playwrightConfig
+} = require('@axe-core/watcher')
+
+/* Get your configuration from environment variables. */
+const { API_KEY, SERVER_URL } = process.env
+
+describe('My Application', () => {
+  let browserContext
+  let page
+  let controller
+
+  before(async () => {
+    browserContext = await playwright.chromium.launchPersistentContext(
+      '',
+      playwrightConfig({
+        axe: {
+          apiKey: API_KEY,
+          serverURL: SERVER_URL
+        },
+        /* Any other Playwright configuration options. */
+        headless: false
+      })
+    )
+
+    page = await browserContext.newPage()
+    controller = new PlaywrightController(page)
+
+    /* Wrap the Playwright browser context. */
+    wrapPlaywright(browserContext, controller)
+  })
+
+  after(async () => {
+    await browserContext.close()
+  })
+
+  afterEach(async () => {
+    /* Flush axe-watcher results after each test. */
+    await controller.flush()
+    await page.close()
+  })
+
+  describe('Login', () => {
+    describe('with valid credentials', () => {
+      it('should login', async () => {
+        await page.goto('https://the-internet.herokuapp.com/login')
+
+        await page.locator('#username').fill('tomsmith')
+        await page.locator('#password').fill('SuperSecretPassword!')
+
+        await page.locator('button[type="submit"]').click()
+
+        const element = await page.waitForSelector('#flash')
+
+        assert.isNotNull(element)
+      })
+    })
+  })
+})

--- a/playwright/basic/tests/login.js
+++ b/playwright/basic/tests/login.js
@@ -7,9 +7,12 @@ const {
 } = require('@axe-core/watcher')
 
 /* Get your configuration from environment variables. */
-const { API_KEY, SERVER_URL } = process.env
+const {
+  API_KEY = '900e0d86-b10a-445c-85a2-c8459178874c',
+  SERVER_URL = 'http://localhost:3000'
+} = process.env
 
-describe('My Application', () => {
+describe('My Login Application', () => {
   let browserContext
   let page
   let controller
@@ -22,8 +25,9 @@ describe('My Application', () => {
           apiKey: API_KEY,
           serverURL: SERVER_URL
         },
-        /* Any other Playwright configuration options. */
-        headless: false
+        //@see: https://playwright.dev/docs/chrome-extensions#headless-mode
+        headless: false,
+        args: ['--headless=new']
       })
     )
 

--- a/playwright/manual-mode/package.json
+++ b/playwright/manual-mode/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "manual-mode",
+  "private": true,
+  "scripts": {
+    "test": "mocha --timeout 5000 'tests/login.js'"
+  },
+  "devDependencies": {
+    "@axe-core/watcher": "^1.8.2-next.41231a52",
+    "chai": "^4.3.7",
+    "mocha": "^10.2.0",
+    "playwright": "^1.33.0"
+  }
+}

--- a/playwright/manual-mode/tests/login.js
+++ b/playwright/manual-mode/tests/login.js
@@ -24,8 +24,9 @@ describe('My Application', () => {
           /* Disable automatic analysis. */
           autoAnalyze: false
         },
-        /* Any other Playwright configuration options. */
-        headless: false
+        //@see: https://playwright.dev/docs/chrome-extensions#headless-mode
+        headless: false,
+        args: ['--headless=new']
       })
     )
 

--- a/playwright/manual-mode/tests/login.js
+++ b/playwright/manual-mode/tests/login.js
@@ -1,0 +1,74 @@
+const { assert } = require('chai')
+const playwright = require('playwright')
+const {
+  wrapPlaywright,
+  PlaywrightController,
+  playwrightConfig
+} = require('@axe-core/watcher')
+
+/* Get your configuration from environment variables. */
+const { API_KEY, SERVER_URL } = process.env
+
+describe('My Application', () => {
+  let browserContext
+  let page
+  let controller
+
+  before(async () => {
+    browserContext = await playwright.chromium.launchPersistentContext(
+      '',
+      playwrightConfig({
+        axe: {
+          apiKey: API_KEY,
+          serverURL: SERVER_URL,
+          /* Disable automatic analysis. */
+          autoAnalyze: false
+        },
+        /* Any other Playwright configuration options. */
+        headless: false
+      })
+    )
+
+    page = await browserContext.newPage()
+    controller = new PlaywrightController(page)
+
+    /* Wrap the Playwright browser context. */
+    wrapPlaywright(browserContext, controller)
+  })
+
+  after(async () => {
+    await browserContext.close()
+  })
+
+  afterEach(async () => {
+    /* Flush axe-watcher results after each test. */
+    await controller.flush()
+    await page.close()
+  })
+
+  describe('Login', () => {
+    describe('with valid credentials', () => {
+      it('should login', async () => {
+        await page.goto('https://the-internet.herokuapp.com/login')
+
+        /* Analyze after navigating to the page. */
+        await controller.analyze()
+
+        await page.locator('#username').fill('tomsmith')
+        await page.locator('#password').fill('SuperSecretPassword!')
+
+        await page.locator('button[type="submit"]').click()
+
+        const element = await page.waitForSelector('#flash')
+
+        /* Analyze after logging in. */
+        await controller.analyze()
+
+        assert.isNotNull(element)
+
+        /* Restart automatic axe analysis. */
+        await controller.start()
+      })
+    })
+  })
+})

--- a/playwright/manual-mode/tests/login.js
+++ b/playwright/manual-mode/tests/login.js
@@ -1,10 +1,6 @@
 const { assert } = require('chai')
 const playwright = require('playwright')
-const {
-  wrapPlaywright,
-  PlaywrightController,
-  playwrightConfig
-} = require('@axe-core/watcher')
+const { PlaywrightController, playwrightConfig } = require('@axe-core/watcher')
 
 /* Get your configuration from environment variables. */
 const { API_KEY, SERVER_URL } = process.env
@@ -32,9 +28,6 @@ describe('My Application', () => {
 
     page = await browserContext.newPage()
     controller = new PlaywrightController(page)
-
-    /* Wrap the Playwright browser context. */
-    wrapPlaywright(browserContext, controller)
   })
 
   after(async () => {
@@ -66,9 +59,6 @@ describe('My Application', () => {
         await controller.analyze()
 
         assert.isNotNull(element)
-
-        /* Restart automatic axe analysis. */
-        await controller.start()
       })
     })
   })


### PR DESCRIPTION
Adds automatic and manual-mode example for Playwright


Closes: https://github.com/dequelabs/watcher-examples/issues/109