### PR TITLE
fix(cypress): Remove `wrapCy`

### DIFF
--- a/cypress/basic/cypress/support/e2e.js
+++ b/cypress/basic/cypress/support/e2e.js
@@ -1,12 +1,6 @@
 // Import the axe-watcher commands.
 require('@axe-core/watcher/dist/cypressCommands')
 
-// Wrap the Cypress driver.
-beforeEach(() => {
-  const { wrapCy } = require('@axe-core/watcher/dist/cypress')
-  wrapCy(cy)
-})
-
 // Flush axe-watcher results after each test.
 afterEach(() => {
   cy.axeFlush()

--- a/cypress/multi-page/cypress/support/e2e.js
+++ b/cypress/multi-page/cypress/support/e2e.js
@@ -1,12 +1,6 @@
 // Import the axe-watcher commands.
 require('@axe-core/watcher/dist/cypressCommands')
 
-// Wrap the Cypress driver.
-beforeEach(() => {
-  const { wrapCy } = require('@axe-core/watcher/dist/cypress')
-  wrapCy(cy)
-})
-
 // Flush axe-watcher results after each test.
 afterEach(() => {
   cy.axeFlush()


### PR DESCRIPTION
We no longer export a `wrapCy` method (it's now done automatically).