### PR TITLE
fix: ensure eslint can run during a pre-commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "eslint-plugin-cypress": "^2.12.1",
     "eslint-plugin-wdio": "^8.0.14",
     "husky": "^8.0.1",
-    "prettier": "^2.7.1"
+    "prettier": "^2.7.1",
+    "typescript": "^5.0.4"
   }
 }


### PR DESCRIPTION
Closes: https://github.com/dequelabs/watcher-examples/issues/126