### PR TITLE
chore: update Playwright and Puppeteer examples with new wrap syntax

### DIFF
--- a/playwright/basic/tests/login.js
+++ b/playwright/basic/tests/login.js
@@ -1,7 +1,7 @@
 const { assert } = require('chai')
 const playwright = require('playwright')
 const {
-  wrapPlaywright,
+  wrapPlaywrightPage,
   PlaywrightController,
   playwrightConfig
 } = require('@axe-core/watcher')
@@ -28,11 +28,14 @@ describe('My Login Application', () => {
       })
     )
 
+    // Create a page instance, using your browser context.
     page = await browserContext.newPage()
+
+    // Initialize the PlaywrightController by passing in the Playwright page.
     controller = new PlaywrightController(page)
 
-    /* Wrap the Playwright browser context. */
-    wrapPlaywright(browserContext, controller)
+    // Use the new wrapped Playwright page instance.
+    page = wrapPlaywrightPage(page, controller)
   })
 
   after(async () => {

--- a/playwright/manual-mode/tests/login.js
+++ b/playwright/manual-mode/tests/login.js
@@ -26,7 +26,10 @@ describe('My Application', () => {
       })
     )
 
+    // Create a page instance, using your browser context.
     page = await browserContext.newPage()
+
+    // Initialize the PlaywrightController by passing in the Playwright page.
     controller = new PlaywrightController(page)
   })
 

--- a/playwright/typescript-multi-page/tests/setup.ts
+++ b/playwright/typescript-multi-page/tests/setup.ts
@@ -3,7 +3,7 @@ import playwright from 'playwright'
 import {
   playwrightConfig,
   PlaywrightController,
-  wrapPlaywright
+  wrapPlaywrightPage
 } from '@axe-core/watcher'
 import assert from 'assert'
 
@@ -29,9 +29,14 @@ before(async () => {
 })
 
 beforeEach(async () => {
+  // Create a page instance, using your browser context.
   page = await browserContext.newPage()
+
+  // Initialize the PlaywrightController by passing in the Playwright page.
   controller = new PlaywrightController(page)
-  wrapPlaywright(browserContext, controller)
+
+  // Use the new wrapped Playwright page instance.
+  page = wrapPlaywrightPage(page, controller)
 })
 
 afterEach(async () => {

--- a/puppeteer/basic/tests/login.js
+++ b/puppeteer/basic/tests/login.js
@@ -1,7 +1,7 @@
 const { assert } = require('chai')
 const puppeteer = require('puppeteer')
 const {
-  wrapPuppeteer,
+  wrapPuppeteerPage,
   PuppeteerController,
   puppeteerConfig
 } = require('@axe-core/watcher')
@@ -24,10 +24,14 @@ describe('My Login Application', () => {
         headless: false
       })
     )
-    const browserContext = browser.browserContexts()[0]
+    // Create a page instance, using your browser instance.
     page = await browser.newPage()
+
+    // Initialize the PuppeteerController by passing in the Puppeteer page.
     controller = new PuppeteerController(page)
-    wrapPuppeteer(browserContext, controller)
+
+    // Use the new wrapped Puppeteer page instance.
+    page = wrapPuppeteerPage(page, controller)
   })
 
   after(async () => {

--- a/puppeteer/typescript-multi-page/tests/setup.ts
+++ b/puppeteer/typescript-multi-page/tests/setup.ts
@@ -1,13 +1,9 @@
 import 'mocha'
-import puppeteer, {
-  type Page,
-  type Browser,
-  type BrowserContext
-} from 'puppeteer'
+import puppeteer, { type Page, type Browser } from 'puppeteer'
 import {
   puppeteerConfig,
   PuppeteerController,
-  wrapPuppeteer
+  wrapPuppeteerPage
 } from '@axe-core/watcher'
 import assert from 'assert'
 
@@ -16,7 +12,6 @@ assert(API_KEY, 'API_KEY is required')
 
 let page: Page
 let browser: Browser
-let browserContext: BrowserContext
 let controller: PuppeteerController
 
 before(async () => {
@@ -29,13 +24,17 @@ before(async () => {
       headless: false
     })
   )
-  browserContext = browser.browserContexts()[0]
 })
 
 beforeEach(async () => {
+  // Create a page instance, using your browser instance.
   page = await browser.newPage()
+
+  // Initialize the PuppeteerController by passing in the Puppeteer page.
   controller = new PuppeteerController(page)
-  wrapPuppeteer(browserContext, controller)
+
+  // Use the new wrapped Puppeteer page instance.
+  page = wrapPuppeteerPage(page, controller)
 })
 
 afterEach(async () => {


### PR DESCRIPTION
This PR pulls amends the Playwright and Puppeteer examples once https://github.com/dequelabs/watcher-examples/pull/165 was merged to use the new syntax and remove the deprecated `wrapPlaywright` and `wrapPuppeteer` functions



