### PR TITLE
chore: update format workflow to use same steps that precommit does

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -3,15 +3,21 @@ name: Format
 on: [pull_request]
 
 jobs:
-  prettier:
+  autocorrect:
     runs-on: ubuntu-latest
+    # Only run on PRs from non-forks
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - name: Cloning the repository
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
-      - name: Prettify the code
-        uses: creyD/prettier_action@v4.3
+      - uses: actions/setup-node@v3
         with:
-          prettier_options: '--write .'
+          node-version: 18
+      - run: yarn install --no-lockfile
+      - run: yarn fmt
+      - run: yarn lint --fix
+      - uses: stefanzweifel/git-auto-commit-action@8756aa072ef5b4a080af5dc8fef36c5d586e521d # tag=v5
+        with:
+          commit_message: ':robot: Automated formatting fixes'

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "eslint-plugin-cypress": "^2.12.1",
     "eslint-plugin-wdio": "^8.0.14",
     "husky": "^8.0.1",
-    "prettier": "^2.7.1",
+    "prettier": "^3.0.3",
     "typescript": "^5.0.4"
   }
 }

--- a/webdriverjs/basic/tests/login.js
+++ b/webdriverjs/basic/tests/login.js
@@ -1,5 +1,9 @@
 const { Builder, until } = require('selenium-webdriver')
-const { wrapWebdriver, webdriverConfig, WebdriverController } = require('@axe-core/watcher')
+const {
+  wrapWebdriver,
+  webdriverConfig,
+  WebdriverController
+} = require('@axe-core/watcher')
 
 /* Get your configuration from environment variables. */
 const { API_KEY, SERVER_URL = 'https://axe.deque.com' } = process.env

--- a/webdriverjs/basic/tests/login.js
+++ b/webdriverjs/basic/tests/login.js
@@ -1,9 +1,5 @@
 const { Builder, until } = require('selenium-webdriver')
-const {
-  wrapWebdriver,
-  webdriverConfig,
-  WebdriverController
-} = require('@axe-core/watcher')
+const { wrapWebdriver, webdriverConfig, WebdriverController } = require('@axe-core/watcher')
 
 /* Get your configuration from environment variables. */
 const { API_KEY, SERVER_URL = 'https://axe.deque.com' } = process.env


### PR DESCRIPTION
When I was updating #153 , I noticed that the autoformatter action and the precommit hook were fighting with each other trying to apply inconsistent prettier changes. That was happening because the workflow was using the latest version of prettier and the precommit hook was using the version specified by package.json.

This PR:

* Updates to latest prettier
* Modifies the format workflow to use the same commands that the precommit hook does, so future prettier updates won't cause the same class of issue to reappear
* Restricts the formatter workflow to only attempt to run on PRs from non-forks, since it would break on forks anyway (it won't have commit permissions)