### PR TITLE
feat: add a basic Cypress TypeScript example using ENV variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ videos/
 screenshots/
 downloads/
 .test-results/
+**/axe-watcher

--- a/cypress/basic-typescript/cypress.config.ts
+++ b/cypress/basic-typescript/cypress.config.ts
@@ -1,10 +1,7 @@
 import { defineConfig } from 'cypress'
 import { cypressConfig } from '@axe-core/watcher'
 
-const {
-  API_KEY = '4771ba7b-3333-4f7b-9c98-07248f4be95f',
-  SERVER_URL = 'https://axe.dequelabs.com'
-} = process.env
+const { API_KEY, SERVER_URL = 'https://axe.deque.com' } = process.env
 
 export default defineConfig(
   cypressConfig({

--- a/cypress/basic-typescript/cypress.config.ts
+++ b/cypress/basic-typescript/cypress.config.ts
@@ -9,10 +9,6 @@ export default defineConfig(
       apiKey: API_KEY,
       serverURL: SERVER_URL
     },
-    env: {
-      USERNAME: 'tomsmith',
-      PASSWORD: 'SuperSecretPassword!'
-    },
     defaultCommandTimeout: 10000
   })
 )

--- a/cypress/basic-typescript/cypress.config.ts
+++ b/cypress/basic-typescript/cypress.config.ts
@@ -9,6 +9,9 @@ export default defineConfig(
       apiKey: API_KEY,
       serverURL: SERVER_URL
     },
+    env: {
+      password: 'SuperSecretPassword!'
+    },
     defaultCommandTimeout: 10000
   })
 )

--- a/cypress/basic-typescript/cypress.config.ts
+++ b/cypress/basic-typescript/cypress.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'cypress'
+import { cypressConfig } from '@axe-core/watcher'
+
+const {
+  API_KEY = '4771ba7b-3333-4f7b-9c98-07248f4be95f',
+  SERVER_URL = 'https://axe.dequelabs.com'
+} = process.env
+
+export default defineConfig(
+  cypressConfig({
+    axe: {
+      apiKey: API_KEY,
+      serverURL: SERVER_URL
+    },
+    env: {
+      USERNAME: 'tomsmith',
+      PASSWORD: 'SuperSecretPassword!'
+    },
+    defaultCommandTimeout: 10000
+  })
+)

--- a/cypress/basic-typescript/cypress.env.json
+++ b/cypress/basic-typescript/cypress.env.json
@@ -1,6 +1,5 @@
 {
   "login": {
-    "username": "tomsmith",
-    "password": "SuperSecretPassword!"
+    "username": "tomsmith"
   }
 }

--- a/cypress/basic-typescript/cypress.env.json
+++ b/cypress/basic-typescript/cypress.env.json
@@ -1,0 +1,6 @@
+{
+  "login": {
+    "username": "tomsmith",
+    "password": "SuperSecretPassword!"
+  }
+}

--- a/cypress/basic-typescript/cypress/e2e/login.cy.ts
+++ b/cypress/basic-typescript/cypress/e2e/login.cy.ts
@@ -6,7 +6,7 @@ describe('My Login Application', () => {
       .get('#username')
       .type(loginCredentials.username)
       .get('#password')
-      .type(loginCredentials.password)
+      .type(Cypress.env('password'))
       .get('button[type="submit"]')
       .click()
       .wait(1000)

--- a/cypress/basic-typescript/cypress/e2e/login.cy.ts
+++ b/cypress/basic-typescript/cypress/e2e/login.cy.ts
@@ -1,10 +1,12 @@
 describe('My Login Application', () => {
   it('should login with valid credentials', () => {
+    const loginCredentials = Cypress.env('login')
+
     cy.visit('https://the-internet.herokuapp.com/login')
       .get('#username')
-      .type(Cypress.env('USERNAME'))
+      .type(loginCredentials.username)
       .get('#password')
-      .type(Cypress.env('PASSWORD'))
+      .type(loginCredentials.password)
       .get('button[type="submit"]')
       .click()
       .wait(1000)

--- a/cypress/basic-typescript/cypress/e2e/login.cy.ts
+++ b/cypress/basic-typescript/cypress/e2e/login.cy.ts
@@ -1,0 +1,14 @@
+describe('My Login Application', () => {
+  it('should login with valid credentials', () => {
+    cy.visit('https://the-internet.herokuapp.com/login')
+      .get('#username')
+      .type(Cypress.env('USERNAME'))
+      .get('#password')
+      .type(Cypress.env('PASSWORD'))
+      .get('button[type="submit"]')
+      .click()
+      .wait(1000)
+      .get('#flash')
+      .should('exist')
+  })
+})

--- a/cypress/basic-typescript/cypress/support/commands.ts
+++ b/cypress/basic-typescript/cypress/support/commands.ts
@@ -1,1 +1,1 @@
-require('@axe-core/watcher/dist/cypressCommands')
+import '@axe-core/watcher/dist/cypressCommands'

--- a/cypress/basic-typescript/cypress/support/commands.ts
+++ b/cypress/basic-typescript/cypress/support/commands.ts
@@ -1,0 +1,1 @@
+require('@axe-core/watcher/dist/cypressCommands')

--- a/cypress/basic-typescript/cypress/support/e2e.ts
+++ b/cypress/basic-typescript/cypress/support/e2e.ts
@@ -1,0 +1,5 @@
+import './commands'
+
+afterEach(() => {
+  cy.axeFlush()
+})

--- a/cypress/basic-typescript/cypress/tsconfig.json
+++ b/cypress/basic-typescript/cypress/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "lib": ["ES6", "DOM"],
+    "types": ["cypress", "node"]
+  },
+  "include": ["**/*.ts"]
+}

--- a/cypress/basic-typescript/package.json
+++ b/cypress/basic-typescript/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "basic-typescript",
+  "description": "A basic Cypress TypeScript project integrating with @axe-core/watcher",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "scripts": {
+    "test": "cypress run --headed --browser=chrome"
+  },
+  "devDependencies": {
+    "@axe-core/watcher": "^3.8.0",
+    "cypress": "^13.8.1",
+    "typescript": "^5.4.5"
+  }
+}

--- a/cypress/basic-typescript/package.json
+++ b/cypress/basic-typescript/package.json
@@ -3,7 +3,6 @@
   "description": "A basic Cypress TypeScript project integrating with @axe-core/watcher",
   "version": "1.0.0",
   "main": "index.js",
-  "license": "MIT",
   "scripts": {
     "test": "cypress run --headed --browser=chrome"
   },


### PR DESCRIPTION
This PR adds a basic Cypress TypeScript example using `env` variables both within the Cypress config and `cyress.env.json` file. 

No QA Required