### PR TITLE
fix(cypress): replace cy.axeFlush with cy.axeWatcherFlush

### DIFF
--- a/cypress/basic/cypress/support/e2e.js
+++ b/cypress/basic/cypress/support/e2e.js
@@ -3,5 +3,5 @@ require('@axe-core/watcher/dist/cypressCommands')
 
 // Flush axe-watcher results after each test.
 afterEach(() => {
-  cy.axeFlush()
+  cy.axeWatcherFlush()
 })

--- a/cypress/iframes/cypress/support/e2e.js
+++ b/cypress/iframes/cypress/support/e2e.js
@@ -3,5 +3,5 @@ require('@axe-core/watcher/dist/cypressCommands')
 
 // Flush axe-watcher results after each test.
 afterEach(() => {
-  cy.axeFlush()
+  cy.axeWatcherFlush()
 })

--- a/cypress/manual-mode/cypress/support/e2e.js
+++ b/cypress/manual-mode/cypress/support/e2e.js
@@ -3,5 +3,5 @@ require('@axe-core/watcher/dist/cypressCommands')
 
 // Flush axe-watcher results after each test.
 afterEach(() => {
-  cy.axeFlush()
+  cy.axeWatcherFlush()
 })

--- a/cypress/multi-page/cypress/support/e2e.js
+++ b/cypress/multi-page/cypress/support/e2e.js
@@ -3,5 +3,5 @@ require('@axe-core/watcher/dist/cypressCommands')
 
 // Flush axe-watcher results after each test.
 afterEach(() => {
-  cy.axeFlush()
+  cy.axeWatcherFlush()
 })


### PR DESCRIPTION
As part of https://github.com/dequelabs/watcher-examples/pull/185 updated watcher to 3.9.0. Changed Cypress examples to reflect changes. 

No QA Required. 