### PR TITLE
chore: bump dependencies in all examples

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,2 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
 
 yarn lint-staged

--- a/cypress/basic/package.json
+++ b/cypress/basic/package.json
@@ -6,6 +6,6 @@
   },
   "devDependencies": {
     "@axe-core/watcher": "^3.11.1",
-    "cypress": "^12.12.0"
+    "cypress": "^13.13.0"
   }
 }

--- a/cypress/iframes/package.json
+++ b/cypress/iframes/package.json
@@ -4,6 +4,6 @@
   },
   "devDependencies": {
     "@axe-core/watcher": "^3.11.1",
-    "cypress": "^12.13.0"
+    "cypress": "^13.13.0"
   }
 }

--- a/cypress/manual-mode/package.json
+++ b/cypress/manual-mode/package.json
@@ -6,6 +6,6 @@
   },
   "devDependencies": {
     "@axe-core/watcher": "^3.11.1",
-    "cypress": "^12.12.0"
+    "cypress": "^13.13.0"
   }
 }

--- a/cypress/multi-page/package.json
+++ b/cypress/multi-page/package.json
@@ -6,6 +6,6 @@
   },
   "devDependencies": {
     "@axe-core/watcher": "^3.11.1",
-    "cypress": "^12.12.0"
+    "cypress": "^13.13.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
-  "name": "axe-watcher-example",
+  "name": "axe-watcher-examples",
   "version": "1.0.0",
   "main": "index.js",
-  "repository": "git@github.com:dequelabs/axe-watcher-example",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dequelabs/watcher-examples.git"
+  },
   "author": "michael-siek <michaelsiek094@gmail.com>",
   "license": "MIT",
   "scripts": {
@@ -12,13 +15,13 @@
     "lint-staged": "yarn lint --fix && yarn fmt"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.29.0",
-    "@typescript-eslint/parser": "^5.29.0",
-    "eslint": "^8.18.0",
-    "eslint-plugin-cypress": "^2.12.1",
-    "eslint-plugin-wdio": "^8.0.14",
-    "husky": "^8.0.1",
-    "prettier": "^3.0.3",
-    "typescript": "^5.0.4"
+    "@typescript-eslint/eslint-plugin": "^7.16.0",
+    "@typescript-eslint/parser": "^7.16.0",
+    "eslint": "^8.56.0",
+    "eslint-plugin-cypress": "^3.3.0",
+    "eslint-plugin-wdio": "^8.37.0",
+    "husky": "^9.0.11",
+    "prettier": "^3.3.2",
+    "typescript": "^5.5.3"
   }
 }

--- a/playwright-test/basic/package.json
+++ b/playwright-test/basic/package.json
@@ -6,6 +6,6 @@
   },
   "devDependencies": {
     "@axe-core/watcher": "^3.11.1",
-    "@playwright/test": "^1.34.3"
+    "@playwright/test": "^1.45.1"
   }
 }

--- a/playwright-test/multi-page/package.json
+++ b/playwright-test/multi-page/package.json
@@ -6,7 +6,7 @@
   },
   "devDependencies": {
     "@axe-core/watcher": "^3.11.1",
-    "@playwright/test": "^1.34.3",
-    "typescript": "^5.0.4"
+    "@playwright/test": "^1.45.1",
+    "typescript": "^5.5.3"
   }
 }

--- a/playwright/basic/package.json
+++ b/playwright/basic/package.json
@@ -6,8 +6,8 @@
   },
   "devDependencies": {
     "@axe-core/watcher": "^3.11.1",
-    "chai": "^4.3.7",
-    "mocha": "^10.2.0",
-    "playwright": "^1.33.0"
+    "chai": "^5.1.1",
+    "mocha": "^10.6.0",
+    "playwright": "^1.45.1"
   }
 }

--- a/playwright/basic/package.json
+++ b/playwright/basic/package.json
@@ -6,7 +6,7 @@
   },
   "devDependencies": {
     "@axe-core/watcher": "^3.11.1",
-    "chai": "^5.1.1",
+    "chai": "^4",
     "mocha": "^10.6.0",
     "playwright": "^1.45.1"
   }

--- a/playwright/manual-mode/package.json
+++ b/playwright/manual-mode/package.json
@@ -6,8 +6,8 @@
   },
   "devDependencies": {
     "@axe-core/watcher": "^3.11.1",
-    "chai": "^4.3.7",
-    "mocha": "^10.2.0",
-    "playwright": "^1.33.0"
+    "chai": "^5.1.1",
+    "mocha": "^10.6.0",
+    "playwright": "^1.45.1"
   }
 }

--- a/playwright/manual-mode/package.json
+++ b/playwright/manual-mode/package.json
@@ -6,7 +6,7 @@
   },
   "devDependencies": {
     "@axe-core/watcher": "^3.11.1",
-    "chai": "^5.1.1",
+    "chai": "^4",
     "mocha": "^10.6.0",
     "playwright": "^1.45.1"
   }

--- a/playwright/typescript-multi-page/package.json
+++ b/playwright/typescript-multi-page/package.json
@@ -8,7 +8,7 @@
     "@axe-core/watcher": "^3.11.1",
     "@types/chai": "^4.3.16",
     "@types/mocha": "^10.0.7",
-    "chai": "^5.1.1",
+    "chai": "^4",
     "mocha": "^10.6.0",
     "playwright": "^1.45.1",
     "ts-node": "^10.9.2",

--- a/playwright/typescript-multi-page/package.json
+++ b/playwright/typescript-multi-page/package.json
@@ -6,12 +6,12 @@
   },
   "devDependencies": {
     "@axe-core/watcher": "^3.11.1",
-    "@types/chai": "^4.3.5",
-    "@types/mocha": "^10.0.1",
-    "chai": "^4.3.7",
-    "mocha": "^10.2.0",
-    "playwright": "^1.34.3",
-    "ts-node": "^10.9.1",
-    "typescript": "^5.0.4"
+    "@types/chai": "^4.3.16",
+    "@types/mocha": "^10.0.7",
+    "chai": "^5.1.1",
+    "mocha": "^10.6.0",
+    "playwright": "^1.45.1",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.5.3"
   }
 }

--- a/puppeteer/basic/package.json
+++ b/puppeteer/basic/package.json
@@ -6,8 +6,8 @@
   },
   "devDependencies": {
     "@axe-core/watcher": "^3.11.1",
-    "chai": "^4.3.7",
-    "mocha": "^10.2.0",
-    "puppeteer": "^20.5.0"
+    "chai": "^5.1.1",
+    "mocha": "^10.6.0",
+    "puppeteer": "^22.13.0"
   }
 }

--- a/puppeteer/basic/package.json
+++ b/puppeteer/basic/package.json
@@ -6,7 +6,7 @@
   },
   "devDependencies": {
     "@axe-core/watcher": "^3.11.1",
-    "chai": "^5.1.1",
+    "chai": "^4",
     "mocha": "^10.6.0",
     "puppeteer": "^22.13.0"
   }

--- a/puppeteer/typescript-multi-page/package.json
+++ b/puppeteer/typescript-multi-page/package.json
@@ -6,12 +6,12 @@
   },
   "devDependencies": {
     "@axe-core/watcher": "^3.11.1",
-    "@types/chai": "^4.3.5",
-    "@types/mocha": "^10.0.1",
-    "chai": "^4.3.7",
-    "mocha": "^10.2.0",
-    "puppeteer": "^20.5.0",
-    "ts-node": "^10.9.1",
-    "typescript": "^5.1.3"
+    "@types/chai": "^4.3.16",
+    "@types/mocha": "^10.0.7",
+    "chai": "^5.1.1",
+    "mocha": "^10.6.0",
+    "puppeteer": "^22.13.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.5.3"
   }
 }

--- a/puppeteer/typescript-multi-page/package.json
+++ b/puppeteer/typescript-multi-page/package.json
@@ -8,7 +8,7 @@
     "@axe-core/watcher": "^3.11.1",
     "@types/chai": "^4.3.16",
     "@types/mocha": "^10.0.7",
-    "chai": "^5.1.1",
+    "chai": "^4",
     "mocha": "^10.6.0",
     "puppeteer": "^22.13.0",
     "ts-node": "^10.9.2",

--- a/wdio/typescript-multi-page/package.json
+++ b/wdio/typescript-multi-page/package.json
@@ -9,7 +9,7 @@
     "@types/chai": "^4.3.16",
     "@types/mocha": "^10.0.7",
     "@types/node": "^20.14.10",
-    "chai": "^5.1.1",
+    "chai": "^4",
     "chromedriver": "^126.0.4",
     "mocha": "^10.6.0",
     "ts-node": "^10.9.2",

--- a/wdio/typescript-multi-page/package.json
+++ b/wdio/typescript-multi-page/package.json
@@ -6,14 +6,14 @@
   },
   "devDependencies": {
     "@axe-core/watcher": "^3.11.1",
-    "@types/chai": "^4.3.5",
-    "@types/mocha": "^10.0.1",
-    "@types/node": "^20.3.1",
-    "chai": "^4.3.7",
-    "chromedriver": "^122.0.4",
-    "mocha": "^10.2.0",
-    "ts-node": "^10.9.1",
-    "typescript": "^5.1.3",
-    "webdriverio": "^8.11.2"
+    "@types/chai": "^4.3.16",
+    "@types/mocha": "^10.0.7",
+    "@types/node": "^20.14.10",
+    "chai": "^5.1.1",
+    "chromedriver": "^126.0.4",
+    "mocha": "^10.6.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.5.3",
+    "webdriverio": "^8.39.1"
   }
 }

--- a/wdio/v7/typescript-basic/package.json
+++ b/wdio/v7/typescript-basic/package.json
@@ -9,7 +9,7 @@
     "@types/chai": "^4.3.16",
     "@types/mocha": "^10.0.7",
     "@types/node": "^20.14.10",
-    "chai": "^5.1.1",
+    "chai": "^4",
     "chromedriver": "^126.0.4",
     "mocha": "^10.6.0",
     "ts-node": "^10.9.2",

--- a/wdio/v7/typescript-basic/package.json
+++ b/wdio/v7/typescript-basic/package.json
@@ -6,14 +6,14 @@
   },
   "devDependencies": {
     "@axe-core/watcher": "^3.11.1",
-    "@types/chai": "^4.3.5",
-    "@types/mocha": "^10.0.1",
-    "@types/node": "^20.3.1",
-    "chai": "^4.3.7",
-    "chromedriver": "^114.0.2",
-    "mocha": "^10.2.0",
-    "ts-node": "^10.9.1",
-    "typescript": "^5.1.3",
+    "@types/chai": "^4.3.16",
+    "@types/mocha": "^10.0.7",
+    "@types/node": "^20.14.10",
+    "chai": "^5.1.1",
+    "chromedriver": "^126.0.4",
+    "mocha": "^10.6.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.5.3",
     "webdriverio": "7.32.1"
   }
 }

--- a/webdriverjs/basic/package.json
+++ b/webdriverjs/basic/package.json
@@ -6,9 +6,9 @@
   },
   "devDependencies": {
     "@axe-core/watcher": "^3.11.1",
-    "chai": "^4.3.7",
-    "chromedriver": "^114.0.1",
-    "mocha": "^10.2.0",
-    "selenium-webdriver": "^4.9.2"
+    "chai": "^5.1.1",
+    "chromedriver": "^126.0.4",
+    "mocha": "^10.6.0",
+    "selenium-webdriver": "^4.22.0"
   }
 }

--- a/webdriverjs/basic/package.json
+++ b/webdriverjs/basic/package.json
@@ -6,7 +6,7 @@
   },
   "devDependencies": {
     "@axe-core/watcher": "^3.11.1",
-    "chai": "^5.1.1",
+    "chai": "^4",
     "chromedriver": "^126.0.4",
     "mocha": "^10.6.0",
     "selenium-webdriver": "^4.22.0"

--- a/webdriverjs/testing/package.json
+++ b/webdriverjs/testing/package.json
@@ -6,9 +6,9 @@
   },
   "devDependencies": {
     "@axe-core/watcher": "^3.11.1",
-    "@types/selenium-webdriver": "^4.1.15",
-    "chromedriver": "^114.0.2",
-    "mocha": "^10.2.0",
-    "selenium-webdriver": "^4.10.0"
+    "@types/selenium-webdriver": "^4.1.24",
+    "chromedriver": "^126.0.4",
+    "mocha": "^10.6.0",
+    "selenium-webdriver": "^4.22.0"
   }
 }

--- a/webdriverjs/typescript-multi-page/package.json
+++ b/webdriverjs/typescript-multi-page/package.json
@@ -6,14 +6,14 @@
   },
   "devDependencies": {
     "@axe-core/watcher": "^3.11.1",
-    "@types/chai": "^4.3.5",
-    "@types/mocha": "^10.0.1",
-    "@types/selenium-webdriver": "^4.1.15",
-    "chai": "^4.3.7",
-    "chromedriver": "^114.0.1",
-    "mocha": "^10.2.0",
-    "selenium-webdriver": "^4.9.2",
-    "ts-node": "^10.9.1",
-    "typescript": "^5.1.3"
+    "@types/chai": "^4.3.16",
+    "@types/mocha": "^10.0.7",
+    "@types/selenium-webdriver": "^4.1.24",
+    "chai": "^5.1.1",
+    "chromedriver": "^126.0.4",
+    "mocha": "^10.6.0",
+    "selenium-webdriver": "^4.22.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.5.3"
   }
 }

--- a/webdriverjs/typescript-multi-page/package.json
+++ b/webdriverjs/typescript-multi-page/package.json
@@ -9,7 +9,7 @@
     "@types/chai": "^4.3.16",
     "@types/mocha": "^10.0.7",
     "@types/selenium-webdriver": "^4.1.24",
-    "chai": "^5.1.1",
+    "chai": "^4",
     "chromedriver": "^126.0.4",
     "mocha": "^10.6.0",
     "selenium-webdriver": "^4.22.0",


### PR DESCRIPTION
This PR amends some of the info on the root level `package.json` some of it was quite outdated.

No QA Required