### PR TITLE
fix: wdio parallel, sequential in manual mode give same results

### DIFF
--- a/wdio/typescript-multi-page/forgot-password.test.ts
+++ b/wdio/typescript-multi-page/forgot-password.test.ts
@@ -1,6 +1,18 @@
 import 'mocha'
 import { assert } from 'chai'
 import { browser } from './setup'
+import { WdioController, wrapWdio } from '@axe-core/watcher'
+
+let controller: WdioController
+
+before(() => {
+  controller = new WdioController(browser)
+  wrapWdio(browser, controller)
+})
+
+afterEach(async () => {
+  await controller.flush()
+})
 
 describe('forgot password', () => {
   it('should contain an email input', async () => {

--- a/wdio/typescript-multi-page/home.test.ts
+++ b/wdio/typescript-multi-page/home.test.ts
@@ -1,6 +1,18 @@
 import 'mocha'
 import { assert } from 'chai'
 import { browser } from './setup'
+import { WdioController, wrapWdio } from '@axe-core/watcher'
+
+let controller: WdioController
+
+before(() => {
+  controller = new WdioController(browser)
+  wrapWdio(browser, controller)
+})
+
+afterEach(async () => {
+  await controller.flush()
+})
 
 describe('home', () => {
   it('should contain a list of links', async () => {

--- a/wdio/typescript-multi-page/login.test.ts
+++ b/wdio/typescript-multi-page/login.test.ts
@@ -1,6 +1,18 @@
 import 'mocha'
 import { assert } from 'chai'
 import { browser } from './setup'
+import { WdioController, wrapWdio } from '@axe-core/watcher'
+
+let controller: WdioController
+
+before(() => {
+  controller = new WdioController(browser)
+  wrapWdio(browser, controller)
+})
+
+afterEach(async () => {
+  await controller.flush()
+})
 
 describe('login', () => {
   it('should contain a username input', async () => {

--- a/wdio/typescript-multi-page/setup.ts
+++ b/wdio/typescript-multi-page/setup.ts
@@ -12,8 +12,7 @@ before(async () => {
     wdioConfig({
       axe: {
         apiKey: API_KEY as string,
-        serverURL: SERVER_URL,
-        autoAnalyze: false
+        serverURL: SERVER_URL
       },
       capabilities: {
         browserName: 'chrome',

--- a/wdio/typescript-multi-page/setup.ts
+++ b/wdio/typescript-multi-page/setup.ts
@@ -1,37 +1,30 @@
 import 'mocha'
-import { wdioConfig, WdioController, wrapWdio } from '@axe-core/watcher'
-import { remote } from 'webdriverio'
+import { wdioConfig } from '@axe-core/watcher'
+import { remote, RemoteOptions } from 'webdriverio'
 
 /* Get your configuration from environment variables. */
 const { API_KEY, SERVER_URL = 'https://axe.deque.com' } = process.env
 
 let browser: WebdriverIO.Browser
-let controller: WdioController
 
 before(async () => {
   browser = await remote(
     wdioConfig({
       axe: {
         apiKey: API_KEY as string,
-        serverURL: SERVER_URL
+        serverURL: SERVER_URL,
+        autoAnalyze: false
       },
       capabilities: {
         browserName: 'chrome',
         'goog:chromeOptions': { args: ['--headless=new'] }
       }
-    })
+    }) as RemoteOptions
   )
-
-  controller = new WdioController(browser)
-  wrapWdio(browser, controller)
-})
-
-afterEach(async () => {
-  await controller.flush()
 })
 
 after(async () => {
   browser.deleteSession()
 })
 
-export { browser, controller }
+export { browser }


### PR DESCRIPTION
This instantiates the `controller` in each test file, ensuring that parallel and sequential runs in manual mode do not carry the state of the controller over to subsequent tests.

Closes dequelabs/jazzband#2067