### PR TITLE
feat: add WDIO cucumber TS example

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,7 @@ jobs:
           - directory: puppeteer/basic
           - directory: puppeteer/typescript-multi-page
           - directory: wdio/test-runner/typescript
+          - directory: wdio/test-runner/cucumber
           - directory: wdio/typescript-multi-page
           - directory: wdio/v7/typescript-basic
             # WDIO v7 does not work on Node > 16. Please refer to `setup.ts` for more information.

--- a/wdio/test-runner/cucumber/features/login.feature
+++ b/wdio/test-runner/cucumber/features/login.feature
@@ -1,0 +1,12 @@
+Feature: The Internet Guinea Pig Website
+
+  Scenario Outline: As a user, I can log into the secure area
+
+    Given I am on the login page
+    When I login with <username> and <password>
+    Then I should see a flash message saying <message>
+
+    Examples:
+      | username | password             | message                        |
+      | tomsmith | SuperSecretPassword! | You logged into a secure area! |
+      | foobar   | barfoo               | Your username is invalid!      |

--- a/wdio/test-runner/cucumber/features/pageobjects/login.page.ts
+++ b/wdio/test-runner/cucumber/features/pageobjects/login.page.ts
@@ -1,0 +1,41 @@
+import { $ } from '@wdio/globals'
+import Page from './page';
+
+/**
+ * sub page containing specific selectors and methods for a specific page
+ */
+class LoginPage extends Page {
+    /**
+     * define selectors using getter methods
+     */
+    public get inputUsername () {
+        return $('#username');
+    }
+
+    public get inputPassword () {
+        return $('#password');
+    }
+
+    public get btnSubmit () {
+        return $('button[type="submit"]');
+    }
+
+    /**
+     * a method to encapsule automation code to interact with the page
+     * e.g. to login using username and password
+     */
+    public async login (username: string, password: string) {
+        await this.inputUsername.setValue(username);
+        await this.inputPassword.setValue(password);
+        await this.btnSubmit.click();
+    }
+
+    /**
+     * overwrite specific options to adapt it to page object
+     */
+    public open () {
+        return super.open('login');
+    }
+}
+
+export default new LoginPage();

--- a/wdio/test-runner/cucumber/features/pageobjects/page.ts
+++ b/wdio/test-runner/cucumber/features/pageobjects/page.ts
@@ -1,0 +1,15 @@
+import { browser } from '@wdio/globals'
+
+/**
+* main page object containing all methods, selectors and functionality
+* that is shared across all page objects
+*/
+export default class Page {
+    /**
+    * Opens a sub page of the page
+    * @param path path of the sub page (e.g. /path/to/page.html)
+    */
+    public open (path: string) {
+        return browser.url(`https://the-internet.herokuapp.com/${path}`)
+    }
+}

--- a/wdio/test-runner/cucumber/features/pageobjects/secure.page.ts
+++ b/wdio/test-runner/cucumber/features/pageobjects/secure.page.ts
@@ -1,0 +1,16 @@
+import { $ } from '@wdio/globals'
+import Page from './page';
+
+/**
+ * sub page containing specific selectors and methods for a specific page
+ */
+class SecurePage extends Page {
+    /**
+     * define selectors using getter methods
+     */
+    public get flashAlert () {
+        return $('#flash');
+    }
+}
+
+export default new SecurePage();

--- a/wdio/test-runner/cucumber/features/step-definitions/steps.ts
+++ b/wdio/test-runner/cucumber/features/step-definitions/steps.ts
@@ -1,0 +1,42 @@
+import {
+  Given,
+  When,
+  Then,
+  AfterStep,
+  BeforeAll
+} from '@wdio/cucumber-framework'
+import { expect } from '@wdio/globals'
+import LoginPage from '../pageobjects/login.page'
+import SecurePage from '../pageobjects/secure.page'
+import { WdioController, wrapWdio } from '@axe-core/watcher'
+
+let controller: WdioController
+
+const pages = {
+  login: LoginPage
+}
+
+BeforeAll(() => {
+  controller = new WdioController(browser)
+  wrapWdio(browser, controller)
+})
+
+Given(/^I am on the (\w+) page$/, async page => {
+  // @ts-expect-error Cucumber generated example code
+  await pages[page].open()
+})
+
+When(/^I login with (\w+) and (.+)$/, async (username, password) => {
+  await LoginPage.login(username, password)
+})
+
+Then(/^I should see a flash message saying (.*)$/, async message => {
+  await expect(SecurePage.flashAlert).toBeExisting()
+  await expect(SecurePage.flashAlert).toHaveText(
+    expect.stringContaining(message)
+  )
+})
+
+AfterStep(async () => {
+  await controller.flush()
+})

--- a/wdio/test-runner/cucumber/package.json
+++ b/wdio/test-runner/cucumber/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "wdio-testrunner-cucumber",
+  "description": "WDIO Testrunner Cucumber @axe-core/watcher example",
+  "private": true,
+  "scripts": {
+    "wdio": "wdio run ./wdio.conf.ts"
+  },
+  "devDependencies": {
+    "@axe-core/watcher": "^3.19.0",
+    "@wdio/cli": "^9.8.0",
+    "@wdio/cucumber-framework": "^9.7.3",
+    "@wdio/local-runner": "^9.8.0",
+    "@wdio/spec-reporter": "^9.8.0"
+  }
+}

--- a/wdio/test-runner/cucumber/package.json
+++ b/wdio/test-runner/cucumber/package.json
@@ -3,7 +3,7 @@
   "description": "WDIO Testrunner Cucumber @axe-core/watcher example",
   "private": true,
   "scripts": {
-    "wdio": "wdio run ./wdio.conf.ts"
+    "test": "wdio run ./wdio.conf.ts"
   },
   "devDependencies": {
     "@axe-core/watcher": "^3.19.0",

--- a/wdio/test-runner/cucumber/tsconfig.json
+++ b/wdio/test-runner/cucumber/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "moduleResolution": "node",
+    "module": "commonjs",
+    "target": "es2019",
+    "lib": ["es2019"],
+    "types": [
+      "node",
+      "@wdio/globals/types",
+      "expect-webdriverio",
+      "@wdio/cucumber-framework"
+    ],
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true
+  },
+  "include": ["test", "wdio.conf.ts", "features"]
+}

--- a/wdio/test-runner/cucumber/wdio.conf.ts
+++ b/wdio/test-runner/cucumber/wdio.conf.ts
@@ -19,10 +19,11 @@ export const config = wdioTestRunner({
   maxInstances: 10,
   capabilities: [
     {
-      browserName: 'chrome'
+      browserName: 'chrome',
+      'goog:chromeOptions': { args: ['--headless=new'] }
     }
   ],
-  logLevel: 'silent',
+  logLevel: 'debug',
   bail: 0,
   waitforTimeout: 10000,
   connectionRetryTimeout: 120000,

--- a/wdio/test-runner/cucumber/wdio.conf.ts
+++ b/wdio/test-runner/cucumber/wdio.conf.ts
@@ -1,0 +1,46 @@
+import { wdioTestRunner } from '@axe-core/watcher'
+import assert from 'assert'
+
+/* Get your configuration from environment variables. */
+const { API_KEY, SERVER_URL = 'https://axe.deque.com' } = process.env
+assert(
+  API_KEY,
+  'Ensure your axe Developer API key is set via the `AXE_API_KEY` environment variable.'
+)
+
+export const config = wdioTestRunner({
+  axe: { apiKey: API_KEY as string, serverURL: SERVER_URL },
+
+  // Remaining WDIO configuration options
+  runner: 'local',
+  tsConfigPath: './tsconfig.json',
+  specs: ['./features/**/*.feature'],
+  exclude: [],
+  maxInstances: 10,
+  capabilities: [
+    {
+      browserName: 'chrome'
+    }
+  ],
+  logLevel: 'silent',
+  bail: 0,
+  waitforTimeout: 10000,
+  connectionRetryTimeout: 120000,
+  connectionRetryCount: 3,
+  framework: 'cucumber',
+  reporters: ['spec'],
+  cucumberOpts: {
+    require: ['./features/step-definitions/steps.ts'],
+    backtrace: false,
+    requireModule: [],
+    dryRun: false,
+    failFast: false,
+    name: [],
+    snippets: true,
+    source: true,
+    strict: false,
+    tagExpression: '',
+    timeout: 60000,
+    ignoreUndefinedDefinitions: false
+  }
+})


### PR DESCRIPTION
This patch adds an WDIO cucumber TS example for @axe-core/watcher. The example boilerplate was generated via the existing [`npx wdio config`](https://webdriver.io/docs/testrunner). 

@axe-core/watcher configuration and setup was added to the following files: 

- `wdio.conf.ts` - Plugs in our `wdioTestRunner` with all of the required params
- `steps.ts` - houses all of the step definitions for each Cucumber feature. This is where we call our `wrapWdio` in the equivalent `before` hook and ensuring we call `flush` in the `afterEach` equivalent hook   

No QA Required