### PR TITLE
ci: use PAT in order to trigger CI tests

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Open PR
         uses: peter-evans/create-pull-request@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT }}
           commit-message: 'chore: Update @axe-core/watcher'
           branch: auto-update-watcher
           base: main


### PR DESCRIPTION
We're unable to use the default `GITHUB_TOKEN` as it cannot run GHA tests, updated to use the PAT in order to get GHA tests to trigger instead of manual intervention

No QA Required