### PR TITLE
fix: wrap the playwright page

### DIFF
--- a/playwright/manual-mode/tests/login.js
+++ b/playwright/manual-mode/tests/login.js
@@ -1,9 +1,9 @@
 const { assert } = require('chai')
 const playwright = require('playwright')
-const { 
+const {
   wrapPlaywrightPage,
-  PlaywrightController, 
-  playwrightConfig 
+  PlaywrightController,
+  playwrightConfig
 } = require('@axe-core/watcher')
 
 /* Get your configuration from environment variables. */
@@ -35,7 +35,7 @@ describe('My Application', () => {
 
     // Initialize the PlaywrightController by passing in the Playwright page.
     controller = new PlaywrightController(page)
-    
+
     // Use the new wrapped Playwright page instance.
     page = wrapPlaywrightPage(page, controller)
   })

--- a/playwright/manual-mode/tests/login.js
+++ b/playwright/manual-mode/tests/login.js
@@ -1,6 +1,10 @@
 const { assert } = require('chai')
 const playwright = require('playwright')
-const { PlaywrightController, playwrightConfig } = require('@axe-core/watcher')
+const { 
+  wrapPlaywrightPage,
+  PlaywrightController, 
+  playwrightConfig 
+} = require('@axe-core/watcher')
 
 /* Get your configuration from environment variables. */
 const { API_KEY, SERVER_URL = 'https://axe.deque.com' } = process.env
@@ -31,6 +35,9 @@ describe('My Application', () => {
 
     // Initialize the PlaywrightController by passing in the Playwright page.
     controller = new PlaywrightController(page)
+    
+    // Use the new wrapped Playwright page instance.
+    page = wrapPlaywrightPage(page, controller)
   })
 
   after(async () => {

--- a/wdio-test-runner/typescript/basic/package.json
+++ b/wdio-test-runner/typescript/basic/package.json
@@ -15,7 +15,7 @@
     "@wdio/mocha-framework": "^8.11.0",
     "@wdio/spec-reporter": "^8.11.2",
     "chai": "^4.3.7",
-    "chromedriver": "^132.0.0",
+    "chromedriver": "^134.0.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.1.3",
     "wdio-chromedriver-service": "^8.1.1"

--- a/wdio-test-runner/typescript/manual-mode/package.json
+++ b/wdio-test-runner/typescript/manual-mode/package.json
@@ -15,7 +15,7 @@
     "@wdio/mocha-framework": "^8.11.0",
     "@wdio/spec-reporter": "^8.11.2",
     "chai": "^4.3.7",
-    "chromedriver": "^132.0.0",
+    "chromedriver": "^134.0.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.1.3",
     "wdio-chromedriver-service": "^8.1.1"

--- a/wdio-test-runner/typescript/typescript-multi-page/package.json
+++ b/wdio-test-runner/typescript/typescript-multi-page/package.json
@@ -15,7 +15,7 @@
     "@wdio/mocha-framework": "^8.11.0",
     "@wdio/spec-reporter": "^8.11.2",
     "chai": "^4.3.7",
-    "chromedriver": "^132.0.0",
+    "chromedriver": "^134.0.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.1.3",
     "wdio-chromedriver-service": "^8.1.1"

--- a/wdio/manual-mode/package.json
+++ b/wdio/manual-mode/package.json
@@ -10,7 +10,7 @@
     "@types/mocha": "^10.0.7",
     "@types/node": "^20.14.10",
     "chai": "^4",
-    "chromedriver": "^132.0.0",
+    "chromedriver": "^134.0.0",
     "mocha": "^10.6.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.3",

--- a/wdio/typescript-multi-page/package.json
+++ b/wdio/typescript-multi-page/package.json
@@ -10,7 +10,7 @@
     "@types/mocha": "^10.0.7",
     "@types/node": "^20.14.10",
     "chai": "^4",
-    "chromedriver": "^126.0.4",
+    "chromedriver": "^134.0.0",
     "mocha": "^10.6.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.3",

--- a/wdio/v7/typescript-basic/package.json
+++ b/wdio/v7/typescript-basic/package.json
@@ -10,7 +10,7 @@
     "@types/mocha": "^10.0.7",
     "@types/node": "^20.14.10",
     "chai": "^4",
-    "chromedriver": "^126.0.4",
+    "chromedriver": "^134.0.0",
     "mocha": "^10.6.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.3",

--- a/webdriverjs/basic/package.json
+++ b/webdriverjs/basic/package.json
@@ -7,7 +7,7 @@
   "devDependencies": {
     "@axe-core/watcher": "^3.19.1",
     "chai": "^4",
-    "chromedriver": "^132.0.0",
+    "chromedriver": "^134.0.0",
     "mocha": "^10.6.0",
     "selenium-webdriver": "^4.22.0"
   }

--- a/webdriverjs/manual-mode/package.json
+++ b/webdriverjs/manual-mode/package.json
@@ -7,7 +7,7 @@
   "devDependencies": {
     "@axe-core/watcher": "^3.19.1",
     "chai": "^4",
-    "chromedriver": "^132.0.0",
+    "chromedriver": "^134.0.0",
     "mocha": "^10.6.0",
     "selenium-webdriver": "^4.22.0"
   }

--- a/webdriverjs/testing/package.json
+++ b/webdriverjs/testing/package.json
@@ -7,7 +7,7 @@
   "devDependencies": {
     "@axe-core/watcher": "^3.19.1",
     "@types/selenium-webdriver": "^4.1.24",
-    "chromedriver": "^132.0.0",
+    "chromedriver": "^134.0.0",
     "mocha": "^10.6.0",
     "selenium-webdriver": "^4.22.0"
   }

--- a/webdriverjs/typescript-multi-page/package.json
+++ b/webdriverjs/typescript-multi-page/package.json
@@ -10,7 +10,7 @@
     "@types/mocha": "^10.0.7",
     "@types/selenium-webdriver": "^4.1.24",
     "chai": "^4",
-    "chromedriver": "^132.0.0",
+    "chromedriver": "^134.0.0",
     "mocha": "^10.6.0",
     "selenium-webdriver": "^4.22.0",
     "ts-node": "^10.9.2",


### PR DESCRIPTION
Closes #230 

QA notes:
Test should run as expected.
In basic/tests/login.js, use this as the body of the test:

```
describe('without any navigation link in beforeeach', () => {
      beforeEach(async () => {
        await controller.start()
      })
      it('should login with valid credentials', async () => {
        await page.goto('https://abcdcomputech.dequecloud.com/')

        await page.locator("a[href='/laptopsandnotebooks.php']").click()

        await page.locator("a[href='/desktops.php']").click()
        await controller.analyze()
      })
      it('Broken',async  () => {
        await page.goto('https://broken-workshop.dequelabs.com/')
        await controller.analyze()
      })
    })
})
```

In manual-mode/tests/login.js, use this as the body of the test:

```
describe('without any navigation link in beforeeach', () => {
      beforeEach(async () => {
        await controller.start()
      })
      it('should login with valid credentials', async () => {
        await page.goto('https://abcdcomputech.dequecloud.com/')

        await page.locator("a[href='/laptopsandnotebooks.php']").click()

        await page.locator("a[href='/desktops.php']").click()
        await controller.analyze()
      })
      it('Broken',async  () => {
        await page.goto('https://broken-workshop.dequelabs.com/')
        await controller.analyze()
      })
    })
})
```

(They only differ by the `beforeEach` block.)

Both should produce 6 results.

QA notes: above