### PR TITLE
feat(all): Add examples for using global config fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ yarn.lock
 videos/
 screenshots/
 downloads/
-.test-results/
+test-results/

--- a/cypress/global-config/cypress.config.js
+++ b/cypress/global-config/cypress.config.js
@@ -1,0 +1,33 @@
+const { defineConfig } = require('cypress')
+const { cypressConfig } = require('@axe-core/watcher')
+
+// Get your configuration from environment variables.
+const { API_KEY, SERVER_URL = 'https://axe.deque.com' } = process.env
+
+module.exports = defineConfig(
+  cypressConfig({
+    axe: {
+      apiKey: API_KEY,
+      serverURL: SERVER_URL,
+      /**
+       * configurationOverrides allows users to override the org-wide settings
+       * configured in the axe account.
+       *
+       * Notes:
+       *  1. If you do not wish to override a specific field, simply omit it from this object.
+       *  2. If you lack permission to override a particular field, the configuration will not proceed.
+       *  3. For more details on using global configurations, visit:
+       *     https://docs.deque.com/developer-hub/2/en/dh-global-configuration
+       *  4. For more information on the configurationOverrides object, see:
+       *     https://docs.deque.com/developer-hub/2/en/dh-global-configuration
+       */
+      configurationOverrides: {
+        accessibilityStandard: 'WCAG 2.2 AAA', // Defines the accessibility standard to apply during axe-core scans
+        axeCoreVersion: '4.10.2', // Specifies the version of axe-core to use
+        bestPractices: true, // Enables or disables axe-core best practice rules
+        experimentalRules: true // Enables or disables experimental axe-core rules
+      }
+    },
+    defaultCommandTimeout: 10000
+  })
+)

--- a/cypress/global-config/cypress.config.js
+++ b/cypress/global-config/cypress.config.js
@@ -19,7 +19,7 @@ module.exports = defineConfig(
        *  3. For more details on using global configurations, visit:
        *     https://docs.deque.com/developer-hub/2/en/dh-global-configuration
        *  4. For more information on the configurationOverrides object, see:
-       *     https://docs.deque.com/developer-hub/2/en/dh-global-configuration
+       *     https://docs.deque.com/developer-hub/2/en/dh-api-reference#configurationoverrides-interface
        */
       configurationOverrides: {
         accessibilityStandard: 'WCAG 2.2 AAA', // Defines the accessibility standard to apply during axe-core scans

--- a/cypress/global-config/cypress/e2e/login.cy.js
+++ b/cypress/global-config/cypress/e2e/login.cy.js
@@ -1,0 +1,14 @@
+describe('My Login Application', () => {
+  it('should login with valid credentials', () => {
+    cy.visit('https://the-internet.herokuapp.com/login')
+      .get('#username')
+      .type('tomsmith')
+      .get('#password')
+      .type('SuperSecretPassword!')
+      .get('button[type="submit"]')
+      .click()
+      .wait(1000)
+      .get('#flash')
+      .should('exist')
+  })
+})

--- a/cypress/global-config/cypress/support/e2e.js
+++ b/cypress/global-config/cypress/support/e2e.js
@@ -1,0 +1,7 @@
+// Import the axe-watcher commands.
+require('@axe-core/watcher/dist/cypressCommands')
+
+// Flush axe-watcher results after each test.
+afterEach(() => {
+  cy.axeWatcherFlush()
+})

--- a/cypress/global-config/package.json
+++ b/cypress/global-config/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "global-config",
+  "private": true,
+  "scripts": {
+    "test": "cypress run --headed --browser=chrome"
+  },
+  "devDependencies": {
+    "@axe-core/watcher": "^3.20.1",
+    "cypress": "^13.13.0"
+  }
+}

--- a/playwright-test/global-config/package.json
+++ b/playwright-test/global-config/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "global-config",
+  "private": true,
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@axe-core/watcher": "^3.20.1",
+    "@playwright/test": "^1.45.1"
+  }
+}

--- a/playwright-test/global-config/playwright.config.js
+++ b/playwright-test/global-config/playwright.config.js
@@ -1,0 +1,3 @@
+const { defineConfig } = require('@playwright/test')
+
+module.exports = defineConfig({ testDir: './tests' })

--- a/playwright-test/global-config/tests/fixtures.js
+++ b/playwright-test/global-config/tests/fixtures.js
@@ -18,7 +18,7 @@ module.exports = playwrightTest({
      *  3. For more details on using global configurations, visit:
      *     https://docs.deque.com/developer-hub/2/en/dh-global-configuration
      *  4. For more information on the configurationOverrides object, see:
-     *     https://docs.deque.com/developer-hub/2/en/dh-global-configuration
+     *     https://docs.deque.com/developer-hub/2/en/dh-api-reference#configurationoverrides-interface
      */
     configurationOverrides: {
       accessibilityStandard: 'WCAG 2.2 AAA', // Defines the accessibility standard to apply during axe-core scans

--- a/playwright-test/global-config/tests/fixtures.js
+++ b/playwright-test/global-config/tests/fixtures.js
@@ -1,0 +1,32 @@
+const { playwrightTest } = require('@axe-core/watcher')
+const assert = require('assert')
+
+const { SERVER_URL = 'https://axe.deque.com', API_KEY } = process.env
+assert(API_KEY, 'API_KEY is required')
+
+module.exports = playwrightTest({
+  axe: {
+    apiKey: API_KEY,
+    serverURL: SERVER_URL,
+    /**
+     * configurationOverrides allows users to override the org-wide settings
+     * configured in the axe account.
+     *
+     * Notes:
+     *  1. If you do not wish to override a specific field, simply omit it from this object.
+     *  2. If you lack permission to override a particular field, the configuration will not proceed.
+     *  3. For more details on using global configurations, visit:
+     *     https://docs.deque.com/developer-hub/2/en/dh-global-configuration
+     *  4. For more information on the configurationOverrides object, see:
+     *     https://docs.deque.com/developer-hub/2/en/dh-global-configuration
+     */
+    configurationOverrides: {
+      accessibilityStandard: 'WCAG 2.2 AAA', // Defines the accessibility standard to apply during axe-core scans
+      axeCoreVersion: '4.10.2', // Specifies the version of axe-core to use
+      bestPractices: true, // Enables or disables axe-core best practice rules
+      experimentalRules: true // Enables or disables experimental axe-core rules
+    }
+  },
+  headless: false,
+  args: ['--headless=new']
+})

--- a/playwright-test/global-config/tests/home.spec.js
+++ b/playwright-test/global-config/tests/home.spec.js
@@ -1,0 +1,17 @@
+const { test, expect } = require('./fixtures')
+
+test.describe('Home page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('https://the-internet.herokuapp.com')
+  })
+
+  test('should contain a list of links', async ({ page }) => {
+    const links = await page.$$('ul li a')
+    expect(links.length).toBeGreaterThan(20)
+  })
+
+  test('should contain a link to the login page', async ({ page }) => {
+    const loginLink = await page.$('ul li a[href="/login"]')
+    expect(loginLink).not.toBeNull()
+  })
+})

--- a/playwright/global-config/package.json
+++ b/playwright/global-config/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "global-config",
+  "private": true,
+  "scripts": {
+    "test": "mocha --timeout 5000 'tests/login.js'"
+  },
+  "devDependencies": {
+    "@axe-core/watcher": "^3.20.1",
+    "chai": "^4",
+    "mocha": "^10.6.0",
+    "playwright": "^1.45.1"
+  }
+}

--- a/playwright/global-config/tests/login.js
+++ b/playwright/global-config/tests/login.js
@@ -1,0 +1,85 @@
+const { assert } = require('chai')
+const playwright = require('playwright')
+const {
+  wrapPlaywrightPage,
+  PlaywrightController,
+  playwrightConfig
+} = require('@axe-core/watcher')
+
+/* Get your configuration from environment variables. */
+const { API_KEY, SERVER_URL = 'https://axe.deque.com' } = process.env
+
+describe('My Login Application', () => {
+  let browserContext
+  let page
+  let controller
+
+  before(async () => {
+    browserContext = await playwright.chromium.launchPersistentContext(
+      '',
+      playwrightConfig({
+        axe: {
+          apiKey: API_KEY,
+          serverURL: SERVER_URL,
+          /**
+           * configurationOverrides allows users to override the org-wide settings
+           * configured in the axe account.
+           *
+           * Notes:
+           *  1. If you do not wish to override a specific field, simply omit it from this object.
+           *  2. If you lack permission to override a particular field, the configuration will not proceed.
+           *  3. For more details on using global configurations, visit:
+           *     https://docs.deque.com/developer-hub/2/en/dh-global-configuration
+           *  4. For more information on the configurationOverrides object, see:
+           *     https://docs.deque.com/developer-hub/2/en/dh-global-configuration
+           */
+          configurationOverrides: {
+            accessibilityStandard: 'WCAG 2.2 AAA', // Defines the accessibility standard to apply during axe-core scans
+            axeCoreVersion: '4.10.2', // Specifies the version of axe-core to use
+            bestPractices: true, // Enables or disables axe-core best practice rules
+            experimentalRules: true // Enables or disables experimental axe-core rules
+          }
+        },
+        //@see: https://playwright.dev/docs/chrome-extensions#headless-mode
+        headless: false,
+        args: ['--headless=new']
+      })
+    )
+
+    // Create a page instance, using your browser context.
+    page = await browserContext.newPage()
+
+    // Initialize the PlaywrightController by passing in the Playwright page.
+    controller = new PlaywrightController(page)
+
+    // Use the new wrapped Playwright page instance.
+    page = wrapPlaywrightPage(page, controller)
+  })
+
+  after(async () => {
+    await browserContext.close()
+  })
+
+  afterEach(async () => {
+    /* Flush axe-watcher results after each test. */
+    await controller.flush()
+    await page.close()
+  })
+
+  describe('Login', () => {
+    describe('with valid credentials', () => {
+      it('should login', async () => {
+        await page.goto('https://the-internet.herokuapp.com/login')
+
+        await page.locator('#username').fill('tomsmith')
+        await page.locator('#password').fill('SuperSecretPassword!')
+
+        await page.locator('button[type="submit"]').click()
+
+        const element = await page.waitForSelector('#flash')
+
+        assert.isNotNull(element)
+      })
+    })
+  })
+})

--- a/playwright/global-config/tests/login.js
+++ b/playwright/global-config/tests/login.js
@@ -31,7 +31,7 @@ describe('My Login Application', () => {
            *  3. For more details on using global configurations, visit:
            *     https://docs.deque.com/developer-hub/2/en/dh-global-configuration
            *  4. For more information on the configurationOverrides object, see:
-           *     https://docs.deque.com/developer-hub/2/en/dh-global-configuration
+           *     https://docs.deque.com/developer-hub/2/en/dh-api-reference#configurationoverrides-interface
            */
           configurationOverrides: {
             accessibilityStandard: 'WCAG 2.2 AAA', // Defines the accessibility standard to apply during axe-core scans

--- a/puppeteer/global-config/package.json
+++ b/puppeteer/global-config/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "global-config",
+  "private": true,
+  "scripts": {
+    "test": "mocha tests/*.js --timeout 20s"
+  },
+  "devDependencies": {
+    "@axe-core/watcher": "^3.20.1",
+    "chai": "^4",
+    "mocha": "^10.6.0",
+    "puppeteer": "^22.13.0"
+  }
+}

--- a/puppeteer/global-config/tests/login.js
+++ b/puppeteer/global-config/tests/login.js
@@ -30,7 +30,7 @@ describe('My Login Application', () => {
            *  3. For more details on using global configurations, visit:
            *     https://docs.deque.com/developer-hub/2/en/dh-global-configuration
            *  4. For more information on the configurationOverrides object, see:
-           *     https://docs.deque.com/developer-hub/2/en/dh-global-configuration
+           *     https://docs.deque.com/developer-hub/2/en/dh-api-reference#configurationoverrides-interface
            */
           configurationOverrides: {
             accessibilityStandard: 'WCAG 2.2 AAA', // Defines the accessibility standard to apply during axe-core scans

--- a/puppeteer/global-config/tests/login.js
+++ b/puppeteer/global-config/tests/login.js
@@ -1,0 +1,81 @@
+const { assert } = require('chai')
+const puppeteer = require('puppeteer')
+const {
+  wrapPuppeteerPage,
+  PuppeteerController,
+  puppeteerConfig
+} = require('@axe-core/watcher')
+
+/* Get your configuration from environment variables. */
+const { API_KEY, SERVER_URL = 'https://axe.deque.com' } = process.env
+
+describe('My Login Application', () => {
+  let browser
+  let page
+  let controller
+
+  before(async () => {
+    browser = await puppeteer.launch(
+      puppeteerConfig({
+        axe: {
+          apiKey: API_KEY,
+          serverURL: SERVER_URL,
+          /**
+           * configurationOverrides allows users to override the org-wide settings
+           * configured in the axe account.
+           *
+           * Notes:
+           *  1. If you do not wish to override a specific field, simply omit it from this object.
+           *  2. If you lack permission to override a particular field, the configuration will not proceed.
+           *  3. For more details on using global configurations, visit:
+           *     https://docs.deque.com/developer-hub/2/en/dh-global-configuration
+           *  4. For more information on the configurationOverrides object, see:
+           *     https://docs.deque.com/developer-hub/2/en/dh-global-configuration
+           */
+          configurationOverrides: {
+            accessibilityStandard: 'WCAG 2.2 AAA', // Defines the accessibility standard to apply during axe-core scans
+            axeCoreVersion: '4.10.2', // Specifies the version of axe-core to use
+            bestPractices: true, // Enables or disables axe-core best practice rules
+            experimentalRules: true // Enables or disables experimental axe-core rules
+          }
+        },
+        headless: false,
+        args: ['--headless=new', '--no-sandbox', '--disable-setuid-sandbox']
+      })
+    )
+    // Create a page instance, using your browser instance.
+    page = await browser.newPage()
+
+    // Initialize the PuppeteerController by passing in the Puppeteer page.
+    controller = new PuppeteerController(page)
+
+    // Use the new wrapped Puppeteer page instance.
+    page = wrapPuppeteerPage(page, controller)
+  })
+
+  after(async () => {
+    await browser.close()
+  })
+
+  afterEach(async () => {
+    /* Flush axe-watcher results after each test. */
+    await controller.flush()
+    await page.close()
+  })
+
+  describe('Login', () => {
+    describe('with valid credentials', () => {
+      it('should login', async () => {
+        await page.goto('https://the-internet.herokuapp.com/login')
+
+        await page.type('#username', 'tomsmith')
+        await page.type('#password', 'SuperSecretPassword!')
+
+        await page.click('button[type="submit"]')
+
+        const element = await page.waitForSelector('#flash')
+        assert.isNotNull(element)
+      })
+    })
+  })
+})

--- a/wdio-test-runner/cucumber/features/login.feature
+++ b/wdio-test-runner/cucumber/features/login.feature
@@ -8,5 +8,6 @@ Feature: The Internet Guinea Pig Website
 
     Examples:
       | username | password             | message                        |
+      | badname  | badpass!             | Your username is invalid!      |
       | tomsmith | SuperSecretPassword! | You logged into a secure area! |
-      | foobar   | barfoo               | Your username is invalid!      |
+

--- a/wdio-test-runner/cucumber/features/step-definitions/steps.ts
+++ b/wdio-test-runner/cucumber/features/step-definitions/steps.ts
@@ -31,6 +31,9 @@ When(/^I login with (\w+) and (.+)$/, async (username, password) => {
 })
 
 Then(/^I should see a flash message saying (.*)$/, async message => {
+  await SecurePage.flashAlert.waitForExist({ timeout: 10000 })
+  await SecurePage.flashAlert.waitForDisplayed({ timeout: 10000 })
+
   await expect(SecurePage.flashAlert).toBeExisting()
   await expect(SecurePage.flashAlert).toHaveText(
     expect.stringContaining(message)

--- a/wdio-test-runner/typescript/global-config/home.test.ts
+++ b/wdio-test-runner/typescript/global-config/home.test.ts
@@ -1,0 +1,17 @@
+import 'mocha'
+import '@wdio/globals'
+import './setup'
+
+describe('home', () => {
+  it('should contain a list of links', async () => {
+    await browser.url('https://the-internet.herokuapp.com')
+    await expect(browser).toHaveTitle('The Internet')
+    await expect((await browser.$$('ul li a')).length).toBeGreaterThan(20)
+  })
+
+  it('should contain a link to the login page', async () => {
+    await browser.url('https://the-internet.herokuapp.com')
+    await expect(browser).toHaveTitle('The Internet')
+    await expect(await browser.$('ul li a[href="/login"]')).toBeDisplayed()
+  })
+})

--- a/wdio-test-runner/typescript/global-config/package.json
+++ b/wdio-test-runner/typescript/global-config/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "global-config",
+  "private": true,
+  "scripts": {
+    "test": "wdio run wdio.config.ts"
+  },
+  "devDependencies": {
+    "@axe-core/watcher": "^3.19.1",
+    "@types/chai": "^4.3.5",
+    "@types/mocha": "^10.0.1",
+    "@types/node": "^20.3.1",
+    "@wdio/cli": "^8.11.2",
+    "@wdio/globals": "^8.11.2",
+    "@wdio/local-runner": "^8.11.2",
+    "@wdio/mocha-framework": "^8.11.0",
+    "@wdio/spec-reporter": "^8.11.2",
+    "chai": "^4.3.7",
+    "chromedriver": "^134.0.5",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.1.3",
+    "wdio-chromedriver-service": "^8.1.1"
+  }
+}

--- a/wdio-test-runner/typescript/global-config/setup.ts
+++ b/wdio-test-runner/typescript/global-config/setup.ts
@@ -1,0 +1,16 @@
+import 'mocha'
+import '@wdio/globals'
+import { WdioController, wrapWdio } from '@axe-core/watcher'
+
+let controller: WdioController
+
+before(() => {
+  controller = new WdioController(browser)
+  wrapWdio(browser, controller)
+})
+
+afterEach(async () => {
+  await controller.flush()
+})
+
+export { controller }

--- a/wdio-test-runner/typescript/global-config/tsconfig.json
+++ b/wdio-test-runner/typescript/global-config/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "types": ["node", "@wdio/globals/types"]
+  }
+}

--- a/wdio-test-runner/typescript/global-config/wdio.config.ts
+++ b/wdio-test-runner/typescript/global-config/wdio.config.ts
@@ -1,0 +1,44 @@
+import { wdioTestRunner } from '@axe-core/watcher'
+
+/* Get your configuration from environment variables. */
+const { API_KEY, SERVER_URL = 'https://axe.deque.com' } = process.env
+
+export const config = wdioTestRunner({
+  axe: {
+    apiKey: API_KEY as string,
+    serverURL: SERVER_URL,
+    /**
+     * configurationOverrides allows users to override the org-wide settings
+     * configured in the axe account.
+     *
+     * Notes:
+     *  1. If you do not wish to override a specific field, simply omit it from this object.
+     *  2. If you lack permission to override a particular field, the configuration will not proceed.
+     *  3. For more details on using global configurations, visit:
+     *     https://docs.deque.com/developer-hub/2/en/dh-global-configuration
+     *  4. For more information on the configurationOverrides object, see:
+     *     https://docs.deque.com/developer-hub/2/en/dh-global-configuration
+     */
+    configurationOverrides: {
+      accessibilityStandard: 'WCAG 2.2 AAA', // Defines the accessibility standard to apply during axe-core scans
+      axeCoreVersion: '4.10.2', // Specifies the version of axe-core to use
+      bestPractices: true, // Enables or disables axe-core best practice rules
+      experimentalRules: true // Enables or disables experimental axe-core rules
+    }
+  },
+  specs: ['home.test.ts'],
+  capabilities: [
+    {
+      browserName: 'chrome',
+      'goog:chromeOptions': { args: ['--headless=new'] }
+    }
+  ],
+  baseUrl: 'https://the-internet.herokuapp.com',
+  services: ['chromedriver'],
+  framework: 'mocha',
+  reporters: ['spec'],
+  maxInstances: 5,
+  mochaOpts: {
+    timeout: 10000
+  }
+})

--- a/wdio-test-runner/typescript/global-config/wdio.config.ts
+++ b/wdio-test-runner/typescript/global-config/wdio.config.ts
@@ -17,7 +17,7 @@ export const config = wdioTestRunner({
      *  3. For more details on using global configurations, visit:
      *     https://docs.deque.com/developer-hub/2/en/dh-global-configuration
      *  4. For more information on the configurationOverrides object, see:
-     *     https://docs.deque.com/developer-hub/2/en/dh-global-configuration
+     *     https://docs.deque.com/developer-hub/2/en/dh-api-reference#configurationoverrides-interface
      */
     configurationOverrides: {
       accessibilityStandard: 'WCAG 2.2 AAA', // Defines the accessibility standard to apply during axe-core scans

--- a/wdio/global-config/home.test.ts
+++ b/wdio/global-config/home.test.ts
@@ -1,0 +1,37 @@
+import 'mocha'
+import { assert } from 'chai'
+import { browser } from './setup'
+import { WdioController, wrapWdio } from '@axe-core/watcher'
+
+let controller: WdioController
+
+before(() => {
+  controller = new WdioController(browser)
+  wrapWdio(browser, controller)
+})
+
+afterEach(async () => {
+  await controller.flush()
+})
+
+describe('home', () => {
+  it('should contain a list of links', async () => {
+    await browser.url('https://the-internet.herokuapp.com')
+
+    const title = await browser.getTitle()
+    assert.equal(title, 'The Internet')
+
+    const links = await browser.$$('ul li a')
+    assert.isAbove(links.length, 20)
+  })
+
+  it('should contain a link to the login page', async () => {
+    await browser.url('https://the-internet.herokuapp.com')
+
+    const title = await browser.getTitle()
+    assert.equal(title, 'The Internet')
+
+    const login = await browser.$('ul li a[href="/login"]')
+    assert.exists(login)
+  })
+})

--- a/wdio/global-config/package.json
+++ b/wdio/global-config/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "global-config",
+  "private": true,
+  "scripts": {
+    "test": "mocha --require ts-node/register --timeout 20s '*.test.ts'"
+  },
+  "devDependencies": {
+    "@axe-core/watcher": "^3.20.1",
+    "@types/chai": "^4.3.16",
+    "@types/mocha": "^10.0.7",
+    "@types/node": "^20.14.10",
+    "chai": "^4",
+    "chromedriver": "^134.0.0",
+    "mocha": "^10.6.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.5.3",
+    "webdriverio": "^8.39.1"
+  }
+}

--- a/wdio/global-config/setup.ts
+++ b/wdio/global-config/setup.ts
@@ -23,7 +23,7 @@ before(async () => {
          *  3. For more details on using global configurations, visit:
          *     https://docs.deque.com/developer-hub/2/en/dh-global-configuration
          *  4. For more information on the configurationOverrides object, see:
-         *     https://docs.deque.com/developer-hub/2/en/dh-global-configuration
+         *     https://docs.deque.com/developer-hub/2/en/dh-api-reference#configurationoverrides-interface
          */
         configurationOverrides: {
           accessibilityStandard: 'WCAG 2.2 AAA', // Defines the accessibility standard to apply during axe-core scans

--- a/wdio/global-config/setup.ts
+++ b/wdio/global-config/setup.ts
@@ -1,0 +1,47 @@
+import 'mocha'
+import { wdioConfig } from '@axe-core/watcher'
+import { remote, RemoteOptions } from 'webdriverio'
+
+/* Get your configuration from environment variables. */
+const { API_KEY, SERVER_URL = 'https://axe.deque.com' } = process.env
+
+let browser: WebdriverIO.Browser
+
+before(async () => {
+  browser = await remote(
+    wdioConfig({
+      axe: {
+        apiKey: API_KEY as string,
+        serverURL: SERVER_URL,
+        /**
+         * configurationOverrides allows users to override the org-wide settings
+         * configured in the axe account.
+         *
+         * Notes:
+         *  1. If you do not wish to override a specific field, simply omit it from this object.
+         *  2. If you lack permission to override a particular field, the configuration will not proceed.
+         *  3. For more details on using global configurations, visit:
+         *     https://docs.deque.com/developer-hub/2/en/dh-global-configuration
+         *  4. For more information on the configurationOverrides object, see:
+         *     https://docs.deque.com/developer-hub/2/en/dh-global-configuration
+         */
+        configurationOverrides: {
+          accessibilityStandard: 'WCAG 2.2 AAA', // Defines the accessibility standard to apply during axe-core scans
+          axeCoreVersion: '4.10.2', // Specifies the version of axe-core to use
+          bestPractices: true, // Enables or disables axe-core best practice rules
+          experimentalRules: true // Enables or disables experimental axe-core rules
+        }
+      },
+      capabilities: {
+        browserName: 'chrome',
+        'goog:chromeOptions': { args: ['--headless=new'] }
+      }
+    }) as RemoteOptions
+  )
+})
+
+after(async () => {
+  browser.deleteSession()
+})
+
+export { browser }

--- a/wdio/global-config/tsconfig.json
+++ b/wdio/global-config/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "lib": ["es2016", "dom"]
+  }
+}

--- a/webdriverjs/global-config/package.json
+++ b/webdriverjs/global-config/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "global-config",
+  "private": true,
+  "scripts": {
+    "test": "mocha --timeout 20s tests/*.js"
+  },
+  "devDependencies": {
+    "@axe-core/watcher": "^3.20.1",
+    "chai": "^4",
+    "chromedriver": "^134.0.0",
+    "mocha": "^10.6.0",
+    "selenium-webdriver": "^4.22.0"
+  }
+}

--- a/webdriverjs/global-config/tests/login.js
+++ b/webdriverjs/global-config/tests/login.js
@@ -33,7 +33,7 @@ describe('My Login Application', () => {
              *  3. For more details on using global configurations, visit:
              *     https://docs.deque.com/developer-hub/2/en/dh-global-configuration
              *  4. For more information on the configurationOverrides object, see:
-             *     https://docs.deque.com/developer-hub/2/en/dh-global-configuration
+             *     https://docs.deque.com/developer-hub/2/en/dh-api-reference#configurationoverrides-interface
              */
             configurationOverrides: {
               accessibilityStandard: 'WCAG 2.2 AAA', // Defines the accessibility standard to apply during axe-core scans

--- a/webdriverjs/global-config/tests/login.js
+++ b/webdriverjs/global-config/tests/login.js
@@ -1,0 +1,77 @@
+const { Builder, until } = require('selenium-webdriver')
+const {
+  wrapWebdriver,
+  webdriverConfig,
+  WebdriverController
+} = require('@axe-core/watcher')
+const { Options } = require('selenium-webdriver/chrome')
+
+/* Get your configuration from environment variables. */
+const { API_KEY, SERVER_URL = 'https://axe.deque.com' } = process.env
+
+describe('My Login Application', () => {
+  let browser
+  let controller
+
+  before(async () => {
+    const options = new Options()
+    options.addArguments('--headless=new')
+    browser = await new Builder()
+      .forBrowser('chrome')
+      .setChromeOptions(
+        webdriverConfig({
+          axe: {
+            apiKey: API_KEY,
+            serverURL: SERVER_URL,
+            /**
+             * configurationOverrides allows users to override the org-wide settings
+             * configured in the axe account.
+             *
+             * Notes:
+             *  1. If you do not wish to override a specific field, simply omit it from this object.
+             *  2. If you lack permission to override a particular field, the configuration will not proceed.
+             *  3. For more details on using global configurations, visit:
+             *     https://docs.deque.com/developer-hub/2/en/dh-global-configuration
+             *  4. For more information on the configurationOverrides object, see:
+             *     https://docs.deque.com/developer-hub/2/en/dh-global-configuration
+             */
+            configurationOverrides: {
+              accessibilityStandard: 'WCAG 2.2 AAA', // Defines the accessibility standard to apply during axe-core scans
+              axeCoreVersion: '4.10.2', // Specifies the version of axe-core to use
+              bestPractices: true, // Enables or disables axe-core best practice rules
+              experimentalRules: true // Enables or disables experimental axe-core rules
+            }
+          },
+          options
+        })
+      )
+      .build()
+    controller = new WebdriverController(browser)
+    browser = wrapWebdriver(browser, controller)
+  })
+
+  after(async () => {
+    await browser.quit()
+  })
+
+  afterEach(async () => {
+    await controller.flush()
+  })
+
+  describe('with valid credentials', () => {
+    it('should login', async () => {
+      await browser.get('https://the-internet.herokuapp.com/login')
+
+      const username = await browser.findElement({ id: 'username' })
+      const password = await browser.findElement({ id: 'password' })
+
+      await username.sendKeys('tomsmith')
+      await password.sendKeys('SuperSecretPassword!')
+
+      const submit = await browser.findElement({ css: 'button[type="submit"]' })
+      await submit.click()
+
+      await browser.wait(until.urlContains('/secure'))
+    })
+  })
+})


### PR DESCRIPTION
Closes: https://github.com/dequelabs/watcher-examples/issues/221