### PR TITLE
fix(wdio/cucumber): context bug in deps and Chrome password alert

### DIFF
--- a/wdio-test-runner/cucumber/features/login.feature
+++ b/wdio-test-runner/cucumber/features/login.feature
@@ -8,5 +8,5 @@ Feature: The Internet Guinea Pig Website
 
     Examples:
       | username | password             | message                        |
-      | tomsmith | SuperSecretPassword! | You logged into a secure area! |
       | foobar   | barfoo               | Your username is invalid!      |
+      | tomsmith | SuperSecretPassword! | You logged into a secure area! |

--- a/wdio-test-runner/cucumber/package.json
+++ b/wdio-test-runner/cucumber/package.json
@@ -7,9 +7,9 @@
   },
   "devDependencies": {
     "@axe-core/watcher": "^3.20.1",
-    "@wdio/cli": "^9.8.0",
-    "@wdio/cucumber-framework": "^9.7.3",
-    "@wdio/local-runner": "^9.8.0",
+    "@wdio/cli": "^9.12.5",
+    "@wdio/cucumber-framework": "^9.12.5",
+    "@wdio/local-runner": "^9.12.5",
     "@wdio/spec-reporter": "^9.8.0"
   }
 }


### PR DESCRIPTION
Tests had not been passing, apparently due to Chrome throwing an alert about `SecretPassword!` being breached. Switching the order of the tests lets that pass.

There was also a context issue that is solved by updating deps.

No QA required