### PR TITLE
chore: migrate to pnpm 11

### DIFF
--- a/.github/actions/install-chrome/action.yml
+++ b/.github/actions/install-chrome/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'The working directory for the install command.'
     required: false
     default: '.'
+  chrome-version:
+    description: 'Chrome / Chromedriver version to install (passed through to browser-actions/setup-chrome). Default: stable.'
+    required: false
+    default: 'stable'
 outputs:
   chrome-path:
     description: 'The path to the Chrome binary.'
@@ -26,5 +30,5 @@ runs:
       id: setup-chrome
       uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd # v2.1.2
       with:
-        chrome-version: 143
+        chrome-version: ${{ inputs.chrome-version }}
         install-chromedriver: true

--- a/.github/actions/install-chrome/action.yml
+++ b/.github/actions/install-chrome/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
     - name: Install Google Chrome for Testing
       id: setup-chrome
-      uses: browser-actions/setup-chrome@b94431e051d1c52dcbe9a7092a4f10f827795416 # v2.1.0
+      uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd # v2.1.2
       with:
         chrome-version: 143
         install-chromedriver: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,45 @@
+version: 2
+
+updates:
+  - package-ecosystem: 'github-actions'
+    rebase-strategy: disabled
+    directories:
+      - '/'
+      - '.github/actions/**/*'
+    schedule:
+      interval: 'weekly'
+      day: 'wednesday'
+      time: '06:37'
+      timezone: 'America/New_York'
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: 'chore'
+    groups:
+      gha-low-risk:
+        update-types:
+          - 'minor'
+          - 'patch'
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: 'npm'
+    rebase-strategy: disabled
+    versioning-strategy: 'increase-if-necessary'
+    directories:
+      - '/'
+      - 'js/**/*'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '06:37'
+      timezone: 'America/New_York'
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: 'chore'
+    groups:
+      npm-low-risk:
+        update-types:
+          - 'minor'
+          - 'patch'
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,16 @@
 version: 2
 
+# NOTE: the `npm` ecosystem is intentionally omitted from this config.
+# This repo is a collection of consumer-facing examples and intentionally
+# does NOT commit lockfiles — every example resolves to the latest
+# published deps on a fresh checkout so users see real-world behavior.
+# With no lockfile to pin, Dependabot npm PRs would either be noise
+# (bumping a range that already resolves to the new version) or actively
+# misleading (suggesting we "upgrade" something we resolve fresh every
+# install). The same property also means CI catches incompatible
+# upstream changes without Dependabot's help.
+# We still want Dependabot to manage GitHub Actions pins below.
+
 updates:
   - package-ecosystem: 'github-actions'
     rebase-strategy: disabled
@@ -16,28 +27,6 @@ updates:
       prefix: 'chore'
     groups:
       gha-low-risk:
-        update-types:
-          - 'minor'
-          - 'patch'
-    cooldown:
-      default-days: 7
-
-  - package-ecosystem: 'npm'
-    rebase-strategy: disabled
-    versioning-strategy: 'increase-if-necessary'
-    directories:
-      - '/'
-      - 'js/**/*'
-    schedule:
-      interval: 'weekly'
-      day: 'monday'
-      time: '06:37'
-      timezone: 'America/New_York'
-    open-pull-requests-limit: 10
-    commit-message:
-      prefix: 'chore'
-    groups:
-      npm-low-risk:
         update-types:
           - 'minor'
           - 'patch'

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -9,17 +9,17 @@ jobs:
     # Only run on PRs from non-forks
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v3
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 18
+          node-version: 24
       - run: pnpm install
       - run: pnpm fmt
       - run: pnpm lint --fix
-      - uses: stefanzweifel/git-auto-commit-action@8756aa072ef5b4a080af5dc8fef36c5d586e521d # tag=v5
+      - uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
         with:
           commit_message: ':robot: Automated formatting fixes'

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,12 +13,13 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-      - run: yarn install --no-lockfile
-      - run: yarn fmt
-      - run: yarn lint --fix
+      - run: pnpm install
+      - run: pnpm fmt
+      - run: pnpm lint --fix
       - uses: stefanzweifel/git-auto-commit-action@8756aa072ef5b4a080af5dc8fef36c5d586e521d # tag=v5
         with:
           commit_message: ':robot: Automated formatting fixes'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 18
+          node-version: 24
       - run: pnpm install
       - run: pnpm lint
 
@@ -53,11 +53,11 @@ jobs:
           - directory: js/webdriverjs/testing
           - directory: js/webdriverjs/typescript-multi-page
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: ${{ matrix.node-version || '20' }}
+          node-version: ${{ matrix.node-version || '24' }}
       - run: mkdir -p ./tmp/browsers
       - uses: ./.github/actions/install-chrome
         id: install-chrome

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,11 +9,12 @@ jobs:
     timeout-minutes: 1
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-      - run: npm install
-      - run: npm run lint
+      - run: pnpm install
+      - run: pnpm lint
 
   smoke-tests:
     name: Smoke Tests
@@ -53,6 +54,7 @@ jobs:
           - directory: js/webdriverjs/typescript-multi-page
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version || '20' }}
@@ -70,8 +72,8 @@ jobs:
       - name: Run tests
         run: |
           cd ${{ matrix.directory }} &&
-          npm install &&
-          npm test
+          pnpm install &&
+          pnpm test
         env:
           API_KEY: ${{ secrets.AXE_DEVHUB_API_KEY }}
           CHROME_BIN: ${{ steps.install-chrome.outputs.chrome-path }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,7 @@ jobs:
         id: install-chrome
         with:
           working-directory: ./tmp/browsers
+          chrome-version: ${{ vars.CHROME_VERSION || 'stable' }}
       - name: Install Playwright
         if: ${{ matrix.playwright }}
         run: npx playwright install

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ package-lock.json
 .yarn
 .env
 yarn.lock
+pnpm-lock.yaml
 videos/
 screenshots/
 downloads/

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,2 @@
 
-yarn lint-staged
+pnpm lint-staged

--- a/js/cypress/basic/package.json
+++ b/js/cypress/basic/package.json
@@ -2,7 +2,7 @@
   "name": "basic",
   "private": true,
   "scripts": {
-    "test": "cypress run --headed --browser=chrome-for-testing"
+    "test": "cypress run --headed --browser \"${CHROME_BIN:-chrome-for-testing}\""
   },
   "devDependencies": {
     "@axe-core/watcher": "^4.0.0",

--- a/js/cypress/basic/pnpm-workspace.yaml
+++ b/js/cypress/basic/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  cypress: true

--- a/js/cypress/global-config/package.json
+++ b/js/cypress/global-config/package.json
@@ -2,7 +2,7 @@
   "name": "global-config",
   "private": true,
   "scripts": {
-    "test": "cypress run --headed --browser=chrome-for-testing"
+    "test": "cypress run --headed --browser \"${CHROME_BIN:-chrome-for-testing}\""
   },
   "devDependencies": {
     "@axe-core/watcher": "^4.0.0",

--- a/js/cypress/global-config/pnpm-workspace.yaml
+++ b/js/cypress/global-config/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  cypress: true

--- a/js/cypress/iframes/package.json
+++ b/js/cypress/iframes/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "test": "cypress run --headed --browser=chrome-for-testing"
+    "test": "cypress run --headed --browser \"${CHROME_BIN:-chrome-for-testing}\""
   },
   "devDependencies": {
     "@axe-core/watcher": "^4.0.0",

--- a/js/cypress/iframes/pnpm-workspace.yaml
+++ b/js/cypress/iframes/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  cypress: true

--- a/js/cypress/manual-mode/package.json
+++ b/js/cypress/manual-mode/package.json
@@ -2,7 +2,7 @@
   "name": "manual-mode",
   "private": true,
   "scripts": {
-    "test": "cypress run --headed --browser=chrome-for-testing"
+    "test": "cypress run --headed --browser \"${CHROME_BIN:-chrome-for-testing}\""
   },
   "devDependencies": {
     "@axe-core/watcher": "^4.0.0",

--- a/js/cypress/manual-mode/pnpm-workspace.yaml
+++ b/js/cypress/manual-mode/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  cypress: true

--- a/js/cypress/multi-page/package.json
+++ b/js/cypress/multi-page/package.json
@@ -2,7 +2,7 @@
   "name": "multi-page",
   "private": true,
   "scripts": {
-    "test": "cypress run --headed --browser chrome-for-testing"
+    "test": "cypress run --headed --browser \"${CHROME_BIN:-chrome-for-testing}\""
   },
   "devDependencies": {
     "@axe-core/watcher": "^4.0.0",

--- a/js/cypress/multi-page/pnpm-workspace.yaml
+++ b/js/cypress/multi-page/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  cypress: true

--- a/js/cypressComponent/basic/package.json
+++ b/js/cypressComponent/basic/package.json
@@ -7,8 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "cypress:open": "cypress open --browser=chrome-for-testing",
-    "cypress:component": "cypress run --component --browser=chrome-for-testing"
+    "cypress:open": "cypress open --browser \"${CHROME_BIN:-chrome-for-testing}\"",
+    "cypress:component": "cypress run --component --browser \"${CHROME_BIN:-chrome-for-testing}\""
   },
   "dependencies": {
     "@cypress/react": "^9.0.1",

--- a/js/cypressComponent/basic/pnpm-workspace.yaml
+++ b/js/cypressComponent/basic/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  cypress: true

--- a/js/cypressComponent/global-config/package.json
+++ b/js/cypressComponent/global-config/package.json
@@ -7,8 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "cypress:open": "cypress open --browser=chrome-for-testing",
-    "cypress:component": "cypress run --component --browser=chrome-for-testing"
+    "cypress:open": "cypress open --browser \"${CHROME_BIN:-chrome-for-testing}\"",
+    "cypress:component": "cypress run --component --browser \"${CHROME_BIN:-chrome-for-testing}\""
   },
   "dependencies": {
     "@cypress/react": "^9.0.1",

--- a/js/cypressComponent/global-config/pnpm-workspace.yaml
+++ b/js/cypressComponent/global-config/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  cypress: true

--- a/js/cypressComponent/manual-mode/package.json
+++ b/js/cypressComponent/manual-mode/package.json
@@ -7,8 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "cypress:open": "cypress open --browser=chrome-for-testing",
-    "cypress:component": "cypress run --component --browser=chrome-for-testing"
+    "cypress:open": "cypress open --browser \"${CHROME_BIN:-chrome-for-testing}\"",
+    "cypress:component": "cypress run --component --browser \"${CHROME_BIN:-chrome-for-testing}\""
   },
   "dependencies": {
     "@cypress/react": "^9.0.1",

--- a/js/cypressComponent/manual-mode/pnpm-workspace.yaml
+++ b/js/cypressComponent/manual-mode/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  cypress: true

--- a/js/cypressComponent/multi-page/package.json
+++ b/js/cypressComponent/multi-page/package.json
@@ -7,8 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "cypress:open": "cypress open --browser=chrome-for-testing",
-    "cypress:component": "cypress run --component --browser=chrome-for-testing"
+    "cypress:open": "cypress open --browser \"${CHROME_BIN:-chrome-for-testing}\"",
+    "cypress:component": "cypress run --component --browser \"${CHROME_BIN:-chrome-for-testing}\""
   },
   "dependencies": {
     "@cypress/react": "^9.0.1",

--- a/js/cypressComponent/multi-page/pnpm-workspace.yaml
+++ b/js/cypressComponent/multi-page/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  cypress: true

--- a/js/playwright-test/basic/tests/fixtures.js
+++ b/js/playwright-test/basic/tests/fixtures.js
@@ -1,4 +1,7 @@
 const { playwrightTest } = require('@axe-core/watcher/playwright-test')
+const {
+  getChromeBinaryPath
+} = require('../../../../utils/setup-chrome-chromedriver.js')
 const assert = require('assert')
 
 const {
@@ -14,6 +17,12 @@ module.exports = playwrightTest({
     projectId: PROJECT_ID,
     serverURL: SERVER_URL
   },
+  /*
+   * Use the same Chrome binary as the rest of the CI matrix
+   * (overridable via CHROME_BIN); falls back to installing
+   * Chrome stable locally when the env var is not set.
+   */
+  executablePath: getChromeBinaryPath(),
   headless: false,
   args: ['--headless=new']
 })

--- a/js/playwright-test/global-config/tests/fixtures.js
+++ b/js/playwright-test/global-config/tests/fixtures.js
@@ -1,4 +1,7 @@
 const { playwrightTest } = require('@axe-core/watcher/playwright-test')
+const {
+  getChromeBinaryPath
+} = require('../../../../utils/setup-chrome-chromedriver.js')
 const assert = require('assert')
 
 const {
@@ -32,6 +35,12 @@ module.exports = playwrightTest({
       experimentalRules: true // Enables or disables experimental axe-core rules
     }
   },
+  /*
+   * Use the same Chrome binary as the rest of the CI matrix
+   * (overridable via CHROME_BIN); falls back to installing
+   * Chrome stable locally when the env var is not set.
+   */
+  executablePath: getChromeBinaryPath(),
   headless: false,
   args: ['--headless=new']
 })

--- a/js/playwright-test/manual-mode/tests/fixtures.ts
+++ b/js/playwright-test/manual-mode/tests/fixtures.ts
@@ -1,4 +1,5 @@
 import { playwrightTest } from '@axe-core/watcher/playwright-test'
+import { getChromeBinaryPath } from '../../../../utils/setup-chrome-chromedriver'
 import assert from 'assert'
 
 const {
@@ -16,6 +17,12 @@ const { test, expect } = playwrightTest({
     /* Disable auto-analyze */
     autoAnalyze: false
   },
+  /*
+   * Use the same Chrome binary as the rest of the CI matrix
+   * (overridable via CHROME_BIN); falls back to installing
+   * Chrome stable locally when the env var is not set.
+   */
+  executablePath: getChromeBinaryPath(),
   headless: false,
   args: ['--headless=new']
 })

--- a/js/playwright-test/multi-page/tests/fixtures.ts
+++ b/js/playwright-test/multi-page/tests/fixtures.ts
@@ -1,4 +1,5 @@
 import { playwrightTest } from '@axe-core/watcher/playwright-test'
+import { getChromeBinaryPath } from '../../../../utils/setup-chrome-chromedriver'
 import assert from 'assert'
 
 const {
@@ -14,6 +15,12 @@ const { test, expect } = playwrightTest({
     projectId: PROJECT_ID,
     serverURL: SERVER_URL
   },
+  /*
+   * Use the same Chrome binary as the rest of the CI matrix
+   * (overridable via CHROME_BIN); falls back to installing
+   * Chrome stable locally when the env var is not set.
+   */
+  executablePath: getChromeBinaryPath(),
   headless: false,
   args: ['--headless=new']
 })

--- a/js/playwright/basic/tests/login.js
+++ b/js/playwright/basic/tests/login.js
@@ -5,6 +5,9 @@ const {
   PlaywrightController,
   playwrightConfig
 } = require('@axe-core/watcher/playwright')
+const {
+  getChromeBinaryPath
+} = require('../../../../utils/setup-chrome-chromedriver.js')
 
 /* Get your configuration from environment variables. */
 const {
@@ -27,6 +30,12 @@ describe('My Login Application', () => {
           projectId: PROJECT_ID,
           serverURL: SERVER_URL
         },
+        /*
+         * Use the same Chrome binary as the rest of the CI matrix
+         * (overridable via CHROME_BIN); falls back to installing
+         * Chrome stable locally when the env var is not set.
+         */
+        executablePath: getChromeBinaryPath(),
         headless: false,
         args: ['--headless=new']
       })

--- a/js/playwright/capture-context/tests/login.js
+++ b/js/playwright/capture-context/tests/login.js
@@ -5,6 +5,9 @@ const {
   PlaywrightController,
   playwrightConfig
 } = require('@axe-core/watcher/playwright')
+const {
+  getChromeBinaryPath
+} = require('../../../../utils/setup-chrome-chromedriver.js')
 
 /* Get your configuration from environment variables. */
 const {
@@ -27,6 +30,12 @@ describe('My Login Application', () => {
           projectId: PROJECT_ID,
           serverURL: SERVER_URL
         },
+        /*
+         * Use the same Chrome binary as the rest of the CI matrix
+         * (overridable via CHROME_BIN); falls back to installing
+         * Chrome stable locally when the env var is not set.
+         */
+        executablePath: getChromeBinaryPath(),
         //@see: https://playwright.dev/docs/chrome-extensions#headless-mode
         headless: false,
         args: ['--headless=new']

--- a/js/playwright/global-config/tests/login.js
+++ b/js/playwright/global-config/tests/login.js
@@ -5,6 +5,9 @@ const {
   PlaywrightController,
   playwrightConfig
 } = require('@axe-core/watcher/playwright')
+const {
+  getChromeBinaryPath
+} = require('../../../../utils/setup-chrome-chromedriver.js')
 
 /* Get your configuration from environment variables. */
 const {
@@ -45,6 +48,12 @@ describe('My Login Application', () => {
             experimentalRules: true // Enables or disables experimental axe-core rules
           }
         },
+        /*
+         * Use the same Chrome binary as the rest of the CI matrix
+         * (overridable via CHROME_BIN); falls back to installing
+         * Chrome stable locally when the env var is not set.
+         */
+        executablePath: getChromeBinaryPath(),
         //@see: https://playwright.dev/docs/chrome-extensions#headless-mode
         headless: false,
         args: ['--headless=new']

--- a/js/playwright/manual-mode/tests/login.js
+++ b/js/playwright/manual-mode/tests/login.js
@@ -5,6 +5,9 @@ const {
   PlaywrightController,
   playwrightConfig
 } = require('@axe-core/watcher/playwright')
+const {
+  getChromeBinaryPath
+} = require('../../../../utils/setup-chrome-chromedriver.js')
 
 /* Get your configuration from environment variables. */
 const {
@@ -29,6 +32,12 @@ describe('My Application', () => {
           /* Disable automatic analysis. */
           autoAnalyze: false
         },
+        /*
+         * Use the same Chrome binary as the rest of the CI matrix
+         * (overridable via CHROME_BIN); falls back to installing
+         * Chrome stable locally when the env var is not set.
+         */
+        executablePath: getChromeBinaryPath(),
         //@see: https://playwright.dev/docs/chrome-extensions#headless-mode
         headless: false,
         args: ['--headless=new']

--- a/js/playwright/typescript-multi-page/package.json
+++ b/js/playwright/typescript-multi-page/package.json
@@ -8,6 +8,7 @@
     "@axe-core/watcher": "^4.0.0",
     "@types/chai": "^4.3.16",
     "@types/mocha": "^10.0.7",
+    "@types/node": "^24",
     "chai": "^4",
     "mocha": "^10.6.0",
     "playwright": "^1.45.1",

--- a/js/playwright/typescript-multi-page/tests/setup.ts
+++ b/js/playwright/typescript-multi-page/tests/setup.ts
@@ -5,6 +5,7 @@ import {
   PlaywrightController,
   wrapPlaywrightPage
 } from '@axe-core/watcher/playwright'
+import { getChromeBinaryPath } from '../../../../utils/setup-chrome-chromedriver'
 import assert from 'assert'
 
 const {
@@ -27,6 +28,12 @@ before(async () => {
         projectId: PROJECT_ID,
         serverURL: SERVER_URL
       },
+      /*
+       * Use the same Chrome binary as the rest of the CI matrix
+       * (overridable via CHROME_BIN); falls back to installing
+       * Chrome stable locally when the env var is not set.
+       */
+      executablePath: getChromeBinaryPath(),
       headless: false,
       args: ['--headless=new']
     })

--- a/js/playwright/typescript-multi-page/tsconfig.json
+++ b/js/playwright/typescript-multi-page/tsconfig.json
@@ -11,6 +11,7 @@
     "target": "ES2020",
     "strict": true,
     "skipLibCheck": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "allowJs": true
   }
 }

--- a/js/puppeteer/basic/pnpm-workspace.yaml
+++ b/js/puppeteer/basic/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  puppeteer: true

--- a/js/puppeteer/basic/tests/login.js
+++ b/js/puppeteer/basic/tests/login.js
@@ -5,6 +5,9 @@ const {
   PuppeteerController,
   puppeteerConfig
 } = require('@axe-core/watcher/puppeteer')
+const {
+  getChromeBinaryPath
+} = require('../../../../utils/setup-chrome-chromedriver.js')
 
 /* Get your configuration from environment variables. */
 const {
@@ -26,6 +29,12 @@ describe('My Login Application', () => {
           projectId: PROJECT_ID,
           serverURL: SERVER_URL
         },
+        /*
+         * Use the same Chrome binary as the rest of the CI matrix
+         * (overridable via CHROME_BIN); falls back to installing
+         * Chrome stable locally when the env var is not set.
+         */
+        executablePath: getChromeBinaryPath(),
         headless: false,
         args: ['--headless=new', '--no-sandbox', '--disable-setuid-sandbox']
       })

--- a/js/puppeteer/global-config/pnpm-workspace.yaml
+++ b/js/puppeteer/global-config/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  puppeteer: true

--- a/js/puppeteer/global-config/tests/login.js
+++ b/js/puppeteer/global-config/tests/login.js
@@ -5,6 +5,9 @@ const {
   PuppeteerController,
   puppeteerConfig
 } = require('@axe-core/watcher/puppeteer')
+const {
+  getChromeBinaryPath
+} = require('../../../../utils/setup-chrome-chromedriver.js')
 
 /* Get your configuration from environment variables. */
 const {
@@ -44,6 +47,12 @@ describe('My Login Application', () => {
             experimentalRules: true // Enables or disables experimental axe-core rules
           }
         },
+        /*
+         * Use the same Chrome binary as the rest of the CI matrix
+         * (overridable via CHROME_BIN); falls back to installing
+         * Chrome stable locally when the env var is not set.
+         */
+        executablePath: getChromeBinaryPath(),
         headless: false,
         args: ['--headless=new', '--no-sandbox', '--disable-setuid-sandbox']
       })

--- a/js/puppeteer/manual-mode/pnpm-workspace.yaml
+++ b/js/puppeteer/manual-mode/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  puppeteer: true

--- a/js/puppeteer/manual-mode/tests/login.js
+++ b/js/puppeteer/manual-mode/tests/login.js
@@ -5,6 +5,9 @@ const {
   PuppeteerController,
   puppeteerConfig
 } = require('@axe-core/watcher/puppeteer')
+const {
+  getChromeBinaryPath
+} = require('../../../../utils/setup-chrome-chromedriver.js')
 
 /* Get your configuration from environment variables. */
 const {
@@ -28,6 +31,12 @@ describe('My Login Application', () => {
           /* Disable automatic analysis */
           autoAnalyze: false
         },
+        /*
+         * Use the same Chrome binary as the rest of the CI matrix
+         * (overridable via CHROME_BIN); falls back to installing
+         * Chrome stable locally when the env var is not set.
+         */
+        executablePath: getChromeBinaryPath(),
         headless: false,
         args: ['--headless=new', '--no-sandbox', '--disable-setuid-sandbox']
       })

--- a/js/puppeteer/typescript-multi-page/package.json
+++ b/js/puppeteer/typescript-multi-page/package.json
@@ -8,6 +8,7 @@
     "@axe-core/watcher": "^4.0.0",
     "@types/chai": "^4.3.16",
     "@types/mocha": "^10.0.7",
+    "@types/node": "^24",
     "chai": "^4",
     "mocha": "^10.6.0",
     "puppeteer": "^24.33.0",

--- a/js/puppeteer/typescript-multi-page/pnpm-workspace.yaml
+++ b/js/puppeteer/typescript-multi-page/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  puppeteer: true

--- a/js/puppeteer/typescript-multi-page/tests/setup.ts
+++ b/js/puppeteer/typescript-multi-page/tests/setup.ts
@@ -5,6 +5,7 @@ import {
   PuppeteerController,
   wrapPuppeteerPage
 } from '@axe-core/watcher/puppeteer'
+import { getChromeBinaryPath } from '../../../../utils/setup-chrome-chromedriver'
 import assert from 'assert'
 
 const {
@@ -26,6 +27,12 @@ before(async () => {
         projectId: PROJECT_ID,
         serverURL: SERVER_URL
       },
+      /*
+       * Use the same Chrome binary as the rest of the CI matrix
+       * (overridable via CHROME_BIN); falls back to installing
+       * Chrome stable locally when the env var is not set.
+       */
+      executablePath: getChromeBinaryPath(),
       headless: false,
       args: ['--headless=new', '--no-sandbox', '--disable-setuid-sandbox']
     })

--- a/js/wdio-test-runner/cucumber/pnpm-workspace.yaml
+++ b/js/wdio-test-runner/cucumber/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  edgedriver: true
+  esbuild: true
+  geckodriver: true

--- a/js/wdio-test-runner/cucumber/wdio.conf.ts
+++ b/js/wdio-test-runner/cucumber/wdio.conf.ts
@@ -1,6 +1,9 @@
 import { wdioTestRunner } from '@axe-core/watcher/webdriverio'
 import assert from 'assert'
-import { getChromeBinaryPath } from '../../../utils/setup-chrome-chromedriver'
+import {
+  getChromeBinaryPath,
+  getChromedriverBinaryPath
+} from '../../../utils/setup-chrome-chromedriver'
 
 /* Get your configuration from environment variables. */
 const {
@@ -29,7 +32,6 @@ export const config = wdioTestRunner({
   capabilities: [
     {
       browserName: 'chrome',
-      browserVersion: 'stable',
       'goog:chromeOptions': {
         args: ['--headless=new', '--no-sandbox'],
         /*
@@ -39,6 +41,16 @@ export const config = wdioTestRunner({
          * This may cause issues, as Watcher does not support branded Chrome >= 139.
          */
         binary: getChromeBinaryPath()
+      },
+      /*
+       * Pin chromedriver to the binary installed alongside Chrome.
+       * Without this, wdio v9's Selenium Manager auto-downloads a
+       * chromedriver matching the current Chrome stable channel, which
+       * will mismatch the older `goog:chromeOptions.binary` above and
+       * fail with "session not created". Override via CHROMEDRIVER_BIN.
+       */
+      'wdio:chromedriverOptions': {
+        binary: getChromedriverBinaryPath()
       }
     }
   ],

--- a/js/wdio-test-runner/typescript/basic/pnpm-workspace.yaml
+++ b/js/wdio-test-runner/typescript/basic/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  chromedriver: true
+  edgedriver: true
+  geckodriver: true

--- a/js/wdio-test-runner/typescript/global-config/pnpm-workspace.yaml
+++ b/js/wdio-test-runner/typescript/global-config/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  chromedriver: true
+  edgedriver: true
+  geckodriver: true

--- a/js/wdio-test-runner/typescript/manual-mode/pnpm-workspace.yaml
+++ b/js/wdio-test-runner/typescript/manual-mode/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  chromedriver: true
+  edgedriver: true
+  geckodriver: true

--- a/js/wdio-test-runner/typescript/typescript-multi-page/pnpm-workspace.yaml
+++ b/js/wdio-test-runner/typescript/typescript-multi-page/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  chromedriver: true
+  edgedriver: true
+  geckodriver: true

--- a/js/wdio/global-config/pnpm-workspace.yaml
+++ b/js/wdio/global-config/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  chromedriver: true
+  edgedriver: true
+  geckodriver: true

--- a/js/wdio/global-config/setup.ts
+++ b/js/wdio/global-config/setup.ts
@@ -1,7 +1,10 @@
 import 'mocha'
 import { wdioConfig } from '@axe-core/watcher/webdriverio'
 import { remote, RemoteOptions } from 'webdriverio'
-import { getChromeBinaryPath } from '../../../utils/setup-chrome-chromedriver'
+import {
+  getChromeBinaryPath,
+  getChromedriverBinaryPath
+} from '../../../utils/setup-chrome-chromedriver'
 
 /* Get your configuration from environment variables. */
 const {
@@ -49,6 +52,15 @@ before(async () => {
            * This may cause issues, as Watcher does not support branded Chrome >= 139.
            */
           binary: getChromeBinaryPath()
+        },
+        /*
+         * Pin chromedriver to the binary installed alongside Chrome
+         * (overridable via CHROMEDRIVER_BIN). Without this, wdio's
+         * Selenium Manager may auto-download a chromedriver that
+         * mismatches the Chrome binary above.
+         */
+        'wdio:chromedriverOptions': {
+          binary: getChromedriverBinaryPath()
         }
       }
     }) as RemoteOptions

--- a/js/wdio/manual-mode/pnpm-workspace.yaml
+++ b/js/wdio/manual-mode/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  chromedriver: true
+  edgedriver: true
+  geckodriver: true

--- a/js/wdio/manual-mode/setup.ts
+++ b/js/wdio/manual-mode/setup.ts
@@ -5,7 +5,10 @@ import {
   wrapWdio
 } from '@axe-core/watcher/webdriverio'
 import { remote } from 'webdriverio'
-import { getChromeBinaryPath } from '../../../utils/setup-chrome-chromedriver'
+import {
+  getChromeBinaryPath,
+  getChromedriverBinaryPath
+} from '../../../utils/setup-chrome-chromedriver'
 
 /* Get your configuration from environment variables. */
 const {
@@ -38,6 +41,15 @@ before(async () => {
            * This may cause issues, as Watcher does not support branded Chrome >= 139.
            */
           binary: getChromeBinaryPath()
+        },
+        /*
+         * Pin chromedriver to the binary installed alongside Chrome
+         * (overridable via CHROMEDRIVER_BIN). Without this, wdio's
+         * Selenium Manager may auto-download a chromedriver that
+         * mismatches the Chrome binary above.
+         */
+        'wdio:chromedriverOptions': {
+          binary: getChromedriverBinaryPath()
         }
       }
     })

--- a/js/wdio/typescript-multi-page/pnpm-workspace.yaml
+++ b/js/wdio/typescript-multi-page/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  chromedriver: true
+  edgedriver: true
+  geckodriver: true

--- a/js/wdio/typescript-multi-page/setup.ts
+++ b/js/wdio/typescript-multi-page/setup.ts
@@ -1,7 +1,10 @@
 import 'mocha'
 import { wdioConfig } from '@axe-core/watcher/webdriverio'
 import { remote, RemoteOptions } from 'webdriverio'
-import { getChromeBinaryPath } from '../../../utils/setup-chrome-chromedriver'
+import {
+  getChromeBinaryPath,
+  getChromedriverBinaryPath
+} from '../../../utils/setup-chrome-chromedriver'
 
 /* Get your configuration from environment variables. */
 const {
@@ -31,6 +34,15 @@ before(async () => {
            * This may cause issues, as Watcher does not support branded Chrome >= 139.
            */
           binary: getChromeBinaryPath()
+        },
+        /*
+         * Pin chromedriver to the binary installed alongside Chrome
+         * (overridable via CHROMEDRIVER_BIN). Without this, wdio's
+         * Selenium Manager may auto-download a chromedriver that
+         * mismatches the Chrome binary above.
+         */
+        'wdio:chromedriverOptions': {
+          binary: getChromedriverBinaryPath()
         }
       }
     }) as RemoteOptions

--- a/js/webdriverjs/basic/pnpm-workspace.yaml
+++ b/js/webdriverjs/basic/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  chromedriver: true

--- a/js/webdriverjs/basic/tests/login.js
+++ b/js/webdriverjs/basic/tests/login.js
@@ -4,9 +4,10 @@ const {
   webdriverConfig,
   WebdriverController
 } = require('@axe-core/watcher/selenium-webdriver')
-const { Options } = require('selenium-webdriver/chrome')
+const { Options, ServiceBuilder } = require('selenium-webdriver/chrome')
 const {
-  getChromeBinaryPath
+  getChromeBinaryPath,
+  getChromedriverBinaryPath
 } = require('../../../../utils/setup-chrome-chromedriver.js')
 
 /* Get your configuration from environment variables. */
@@ -31,8 +32,16 @@ describe('My Login Application', () => {
      * This may cause issues, as Watcher does not support branded Chrome >= 139.
      */
     options.setBinaryPath(getChromeBinaryPath())
+    /*
+     * Pin chromedriver to the binary installed alongside Chrome
+     * (overridable via CHROMEDRIVER_BIN). Without this, selenium
+     * uses whatever chromedriver is on PATH, which may not match
+     * the Chrome binary above.
+     */
+    const service = new ServiceBuilder(getChromedriverBinaryPath())
     browser = await new Builder()
       .forBrowser('chrome')
+      .setChromeService(service)
       .setChromeOptions(
         webdriverConfig({
           axe: {

--- a/js/webdriverjs/global-config/pnpm-workspace.yaml
+++ b/js/webdriverjs/global-config/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  chromedriver: true

--- a/js/webdriverjs/global-config/tests/login.js
+++ b/js/webdriverjs/global-config/tests/login.js
@@ -4,9 +4,10 @@ const {
   webdriverConfig,
   WebdriverController
 } = require('@axe-core/watcher/selenium-webdriver')
-const { Options } = require('selenium-webdriver/chrome')
+const { Options, ServiceBuilder } = require('selenium-webdriver/chrome')
 const {
-  getChromeBinaryPath
+  getChromeBinaryPath,
+  getChromedriverBinaryPath
 } = require('../../../../utils/setup-chrome-chromedriver.js')
 
 /* Get your configuration from environment variables. */
@@ -31,8 +32,16 @@ describe('My Login Application', () => {
      * This may cause issues, as Watcher does not support branded Chrome >= 139.
      */
     options.setBinaryPath(getChromeBinaryPath())
+    /*
+     * Pin chromedriver to the binary installed alongside Chrome
+     * (overridable via CHROMEDRIVER_BIN). Without this, selenium
+     * uses whatever chromedriver is on PATH, which may not match
+     * the Chrome binary above.
+     */
+    const service = new ServiceBuilder(getChromedriverBinaryPath())
     browser = await new Builder()
       .forBrowser('chrome')
+      .setChromeService(service)
       .setChromeOptions(
         webdriverConfig({
           axe: {

--- a/js/webdriverjs/manual-mode/pnpm-workspace.yaml
+++ b/js/webdriverjs/manual-mode/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  chromedriver: true

--- a/js/webdriverjs/manual-mode/tests/login.js
+++ b/js/webdriverjs/manual-mode/tests/login.js
@@ -4,9 +4,10 @@ const {
   webdriverConfig,
   WebdriverController
 } = require('@axe-core/watcher/selenium-webdriver')
-const { Options } = require('selenium-webdriver/chrome')
+const { Options, ServiceBuilder } = require('selenium-webdriver/chrome')
 const {
-  getChromeBinaryPath
+  getChromeBinaryPath,
+  getChromedriverBinaryPath
 } = require('../../../../utils/setup-chrome-chromedriver.js')
 
 /* Get your configuration from environment variables. */
@@ -31,8 +32,16 @@ describe('My Login Application', () => {
      * This may cause issues, as Watcher does not support branded Chrome >= 139.
      */
     options.setBinaryPath(getChromeBinaryPath())
+    /*
+     * Pin chromedriver to the binary installed alongside Chrome
+     * (overridable via CHROMEDRIVER_BIN). Without this, selenium
+     * uses whatever chromedriver is on PATH, which may not match
+     * the Chrome binary above.
+     */
+    const service = new ServiceBuilder(getChromedriverBinaryPath())
     browser = await new Builder()
       .forBrowser('chrome')
+      .setChromeService(service)
       .setChromeOptions(
         webdriverConfig({
           axe: {

--- a/js/webdriverjs/testing/pnpm-workspace.yaml
+++ b/js/webdriverjs/testing/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  chromedriver: true

--- a/js/webdriverjs/testing/tests/login.js
+++ b/js/webdriverjs/testing/tests/login.js
@@ -5,9 +5,10 @@ const {
   webdriverConfig,
   WebdriverController
 } = require('@axe-core/watcher/selenium-webdriver')
-const { Options } = require('selenium-webdriver/chrome')
+const { Options, ServiceBuilder } = require('selenium-webdriver/chrome')
 const {
-  getChromeBinaryPath
+  getChromeBinaryPath,
+  getChromedriverBinaryPath
 } = require('../../../../utils/setup-chrome-chromedriver.js')
 
 /* Get your configuration from environment variables. */
@@ -39,7 +40,15 @@ suite(env => {
       if (env.browser.name !== 'chrome') {
         browser = await env.builder().build()
       } else {
+        /*
+         * Pin chromedriver to the binary installed alongside Chrome
+         * (overridable via CHROMEDRIVER_BIN). Without this, selenium
+         * uses whatever chromedriver is on PATH, which may not match
+         * the Chrome binary above.
+         */
+        const service = new ServiceBuilder(getChromedriverBinaryPath())
         browser = await builder
+          .setChromeService(service)
           .setChromeOptions(
             webdriverConfig({
               axe: {

--- a/js/webdriverjs/typescript-multi-page/package.json
+++ b/js/webdriverjs/typescript-multi-page/package.json
@@ -8,6 +8,7 @@
     "@axe-core/watcher": "^4.0.0",
     "@types/chai": "^4.3.16",
     "@types/mocha": "^10.0.7",
+    "@types/node": "^24",
     "@types/selenium-webdriver": "^4.1.24",
     "chai": "^4",
     "chromedriver": "^143.0.0",

--- a/js/webdriverjs/typescript-multi-page/pnpm-workspace.yaml
+++ b/js/webdriverjs/typescript-multi-page/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  chromedriver: true

--- a/js/webdriverjs/typescript-multi-page/tests/setup.ts
+++ b/js/webdriverjs/typescript-multi-page/tests/setup.ts
@@ -5,8 +5,11 @@ import {
   webdriverConfig,
   WebdriverController
 } from '@axe-core/watcher/selenium-webdriver'
-import { Options } from 'selenium-webdriver/chrome'
-import { getChromeBinaryPath } from '../../../../utils/setup-chrome-chromedriver'
+import { Options, ServiceBuilder } from 'selenium-webdriver/chrome'
+import {
+  getChromeBinaryPath,
+  getChromedriverBinaryPath
+} from '../../../../utils/setup-chrome-chromedriver'
 
 /* Get your configuration from environment variables. */
 const {
@@ -29,8 +32,16 @@ before(async () => {
    * This may cause issues, as Watcher does not support branded Chrome >= 139.
    */
   options.setBinaryPath(getChromeBinaryPath())
+  /*
+   * Pin chromedriver to the binary installed alongside Chrome
+   * (overridable via CHROMEDRIVER_BIN). Without this, selenium
+   * uses whatever chromedriver is on PATH, which may not match
+   * the Chrome binary above.
+   */
+  const service = new ServiceBuilder(getChromedriverBinaryPath())
   browser = await new Builder()
     .forBrowser('chrome')
+    .setChromeService(service)
     .setChromeOptions(
       webdriverConfig({
         axe: {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
     "fmt": "prettier --write .",
     "prepare": "husky install",
     "lint": "eslint .",
-    "lint-staged": "yarn lint --fix && yarn fmt"
+    "lint-staged": "pnpm lint --fix && pnpm fmt"
   },
+  "packageManager": "pnpm@11.2.0",
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^7.16.0",
     "@typescript-eslint/parser": "^7.16.0",


### PR DESCRIPTION
## Summary

- Declare pnpm 11 as the repo's package manager (`"packageManager": "pnpm@11.2.0"` in root `package.json`); swap remaining `yarn` invocations (root `lint-staged` script + `.husky/pre-commit`) for `pnpm` equivalents.
- Convert CI to pnpm: `.github/workflows/format.yml` and `.github/workflows/test.yml` (both `lint` and `smoke-tests` jobs) now use `pnpm/action-setup` (version resolved from `packageManager`) and run `pnpm install` / `pnpm lint` / `pnpm test`. No `cache: 'pnpm'` and no `--frozen-lockfile` — this repo intentionally does not commit a lockfile so examples always resolve to the latest published deps.
- Add `pnpm-lock.yaml` to `.gitignore` to make the no-lockfile policy explicit.
- `.github/dependabot.yml` ships **github-actions only** per the `api-team:dependabot-config` skill (composite action included via the `directories:` form). The `npm` ecosystem is intentionally **excluded** and the reason is documented inline: this repo doesn't commit lockfiles, so Dependabot npm PRs would either be redundant or actively misleading.

Example `README.md`s and example `package.json` files were intentionally left on `npm` — they're user-facing how-to-run docs and shouldn't force end users onto pnpm.

### Workflow hygiene

- Bumped `node-version` from 18 (lint + format jobs) and 20 (smoke-tests matrix default) to **24**. Required: pnpm 11 needs Node 22+, so 18 was no longer viable. Picked 24 because it's the current active LTS (opened October 2025), which also gets the smoke-tests off the soon-to-be-EOL Node 20 line.
- Pinned every external action to a full commit SHA with an inline version comment via `npx actions-up`. Standard supply-chain hygiene per the `api-team:github-actions-workflow` skill — floating tags like `@v4` can be silently rewritten by the action author, SHAs can't.
  - `actions/checkout` v3/v4 → `de0fac2` # v6.0.2
  - `actions/setup-node` v3/v4 → `48b55a0` # v6.4.0
  - `pnpm/action-setup` v4 → `0e279bb` # v6.0.8
  - `stefanzweifel/git-auto-commit-action` (old SHA) → `04702ed` # v7.1.0
  - `browser-actions/setup-chrome` (old SHA) → `2e1d749` # v2.1.2 (in the `install-chrome` composite action)

`semantic-pr-footer.yml`'s `dequelabs/axe-api-team-public/.github/actions/semantic-pr-footer-v1@main` was intentionally left as-is: the `-v1` baked into the action path is the version pin, and dequelabs-owned actions sit inside the team's trust boundary per the workflow skill.

### pnpm 10+ build-script allowlists

pnpm 10+ refuses to run install scripts by default. Each example that needs them now ships a `pnpm-workspace.yaml` with an `allowBuilds:` map, scoped tight to just what that area needs (verified against the actual CI failure for each):

- `cypress/*` + `cypressComponent/*` → `cypress: true`
- `puppeteer/*` → `puppeteer: true`
- `webdriverjs/*` → `chromedriver: true`
- `wdio/*` + `wdio-test-runner/typescript/*` → `chromedriver`, `edgedriver`, `geckodriver`
- `wdio-test-runner/cucumber` (v9, esbuild-compiled config) → `edgedriver`, `esbuild`, `geckodriver`

`pnpm.onlyBuiltDependencies` in `package.json` is **not** read in pnpm 11 — only the `allowBuilds` map in `pnpm-workspace.yaml` is. We verified this locally before committing.

### Browser + chromedriver consistency (the reason for the matrix going green)

Goal: every smoke-test matrix entry drives **the same Chrome and chromedriver** the workflow installs, so we stop hitting random failures every time Chrome stable ticks and one framework's bundled browser falls out of sync with another's chromedriver. Browser/driver drift was already costing us a wdio v9 mismatch (`session not created: This version of ChromeDriver only supports Chrome version 148`) and would have kept costing us as Chrome stable advances.

What landed:

- **Composite action** (`.github/actions/install-chrome/action.yml`) now takes a `chrome-version` input, defaulting to `stable`. `test.yml` passes `${{ vars.CHROME_VERSION || 'stable' }}` so CI rides the latest Chrome stable channel by default; we can pin via a repo-level `CHROME_VERSION` variable if a specific Chrome version ever needs to be locked to dodge a regression. The composite installs Chrome and chromedriver from the same `browser-actions/setup-chrome` run, so the two binaries are matched by construction.
- **CI env** exposes the installed binaries as `CHROME_BIN` and `CHROMEDRIVER_BIN` on the test step. Every example reads them through the shared `utils/setup-chrome-chromedriver.js` helper.
- **Every example now consumes those env vars**, not the bundle that ships with its framework:
  - Cypress + cypressComponent (9 package.json files): test scripts use `cypress run --browser "${CHROME_BIN:-chrome-for-testing}"`.
  - Puppeteer (4 setups): `puppeteerConfig({ ..., executablePath: getChromeBinaryPath() })`.
  - Playwright standalone (5 setups): `playwrightConfig({ ..., executablePath: getChromeBinaryPath() })`.
  - Playwright-test (4 fixtures): `playwrightTest({ ..., executablePath: getChromeBinaryPath() })`.
  - Selenium-webdriver (5 setups): adds `chrome.ServiceBuilder(getChromedriverBinaryPath())` via `Builder#setChromeService`.
  - wdio standalone (3 setups): adds `wdio:chromedriverOptions.binary` capability.
  - wdio-test-runner v8 (4 configs): already passed both via `wdio-chromedriver-service`.
  - wdio-test-runner/cucumber (v9): adds `wdio:chromedriverOptions.binary`; drops `browserVersion: 'stable'` so wdio's Selenium Manager doesn't auto-download a mismatched chromedriver.

Local runs still work without env vars: the helper falls back to `@puppeteer/browsers install chrome@stable / chromedriver@stable`.

### Misc pre-existing bugs fixed along the way

Adding `"@types/node": "^24"` to three TS examples (`playwright/typescript-multi-page`, `puppeteer/typescript-multi-page`, `webdriverjs/typescript-multi-page`) — their `tsconfig.json` uses `module: nodenext` and they import `assert` / use `process.env`, but the package was missing `@types/node`. Pre-existing bug unmasked when the pnpm allowBuilds fix let those matrix entries get past install for the first time.

## Test plan

- [ ] `Format / autocorrect` workflow runs `pnpm install` / `pnpm fmt` / `pnpm lint --fix` cleanly on Node 24
- [ ] `Tests / Lint` job passes with pnpm on Node 24
- [ ] `Tests / Smoke Tests` matrix entries (cypress, cypressComponent, puppeteer, playwright, playwright-test, webdriverjs, wdio, wdio-test-runner including cucumber) install each example with `pnpm install` and run `pnpm test` on Node 24, all driving the same Chrome + chromedriver from the `install-chrome` composite
- [ ] Dependabot parses `.github/dependabot.yml` without errors (check Insights → Dependency graph → Dependabot after merge)

Fixes: #269